### PR TITLE
新增 Release workflow 并重写面向使用者的 README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Tag ${GITHUB_REF_NAME} is not on main branch, skipping release."
+            exit 1
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          # 项目零依赖无 go.sum，关闭缓存避免报错
+          cache: false
+
+      - name: Cross-compile binaries
+        env:
+          CGO_ENABLED: "0"
+        run: |
+          mkdir -p release
+          targets=(
+            "linux amd64"
+            "linux arm64"
+            "windows amd64"
+            "darwin amd64"
+            "darwin arm64"
+          )
+          for target in "${targets[@]}"; do
+            read -r goos goarch <<< "$target"
+            ext=""
+            [ "$goos" = "windows" ] && ext=".exe"
+            out="show-me-the-story${ext}"
+            echo "Building ${goos}/${goarch}..."
+            GOOS="$goos" GOARCH="$goarch" go build -trimpath -ldflags "-s -w" -o "$out" .
+            name="show-me-the-story-${GITHUB_REF_NAME}-${goos}-${goarch}"
+            if [ "$goos" = "windows" ]; then
+              zip -q "release/${name}.zip" "$out"
+            else
+              tar -czf "release/${name}.tar.gz" "$out"
+            fi
+            rm -f "$out"
+          done
+          ls -lh release/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" release/* \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ task dev                              # 编译并启动 Go 后端
 | `prompts.go` | `RenderPrompt`（`{{.KeyName}}` 替换）、`DefaultPrompts` 变量（所有内置提示词模板） |
 | `filesys.go` | `writeFileImpl`、`deleteFileImpl`、`renameFileImpl` |
 | `embeds/skills/*.md` | 内置 Skill 文件（YAML frontmatter + prompt body），通过 `//go:embed` 嵌入 |
+| `.github/workflows/release.yml` | GitHub Actions 发布流程：推送 `v*` tag 时校验 tag 在 main 分支上，构建前端 + 交叉编译 5 个目标（linux/windows/macOS × amd64/arm64，windows 仅 amd64），打包 tar.gz/zip 并用 `gh` 创建 Release |
 
 ### 前端文件（`frontend/`）
 

--- a/README.md
+++ b/README.md
@@ -1,224 +1,153 @@
-# AI 小说生成器
+# Show Me The Story — AI 小说生成器
 
-一个基于 OpenAI 兼容 API 的长篇小说自动生成工具。程序本身不包含任何小说内容，所有故事设定、写作风格、角色描述均由用户通过 Web UI 配置，或由 AI 在大纲阶段自动生成。
+一个开箱即用的长篇小说 AI 创作工具。单个可执行文件，内置完整 Web 界面，连接任意 OpenAI 兼容 API（OpenAI、DeepSeek、本地 Ollama / LM Studio 等）即可自动生成大纲并逐章创作长篇小说。
 
-## 功能特性
+程序本身不包含任何小说内容——故事类型、世界观、角色、写作风格全部由你配置，或交给 AI 自动生成。
 
-- **零配置启动**：编译后单二进制即可直接运行，缺失配置文件时自动生成空白默认配置
-- **Web UI**：浏览器操作，支持实时日志流（SSE）
-- **内容无关**：程序代码不包含任何领域特定内容，适用于任意类型的小说创作
-- **两阶段流程**：大纲生成 → 逐章创作
-- **伏笔系统**：AI 自动规划伏笔方案，每章写作时注入活跃伏笔上下文，完成后自动追踪伏笔状态
-- **用户审核**：每章完成后可审核、提出修改意见，AI 会修改当前章节并调整后续大纲
-- **断点恢复**：任意步骤中断后重新运行，自动从上次中断处继续
-- **事实核查**：每章写完后自动进行一致性检查，不通过则重新生成
-- **零外部依赖**：仅使用 Go 标准库
+## 功能亮点
+
+- **单文件运行**：一个二进制文件 + 一个浏览器，无需安装数据库或其他依赖
+- **多项目管理**：每部小说一个独立项目，可随时切换、新建、删除
+- **两阶段创作**：先生成全书大纲供你审核修订，确认后逐章写作
+- **逐章审核**：每章生成后可确认、提修改意见，AI 定向修订而不影响其他章节
+- **自动确认模式**：开启后 AI 自动逐章连写，无需手动逐章确认，可随时开关
+- **结构化设定**：角色、世界观、组织、人物关系独立管理，写作时自动注入相关上下文；支持 AI 一键生成初始设定
+- **关系图谱**：可视化展示角色 / 组织 / 世界观之间的关系网络
+- **伏笔系统**：AI 规划伏笔方案，写作时注入活跃伏笔，完成后自动追踪埋设 → 推进 → 回收，超期未回收自动告警
+- **事实核查**：每章写完自动做一致性检查，不通过自动重写
+- **续写已有作品**：粘贴已有文本，AI 分析提取设定与章节摘要后接着往下写
+- **去 AI 味**：内置润色技能（禁用 AI 高频套话、口语化改写等），一键对章节去 AI 味
+- **技能系统**：内置写作技巧 / 润色技能可选启用，也支持项目级自定义技能
+- **AI 助理**：内置聊天助理，可通过对话查询和修改项目的设定、大纲、章节（破坏性操作有多层防护）
+- **实时流式输出**：生成过程逐字实时展示，附带日志面板和进度提示
+- **断点续作**：进度随时落盘，关闭程序后重新打开自动恢复
+- **导出**：一键导出全书 TXT，章节文件同时以 Markdown 保存在项目目录中
 
 ## 快速开始
 
-### 1. 编译
+### 1. 获取程序
 
-```bash
-go build -o showmethestory .
-```
+下载对应平台的发布版本，或自行编译（见文末「开发」一节）。
 
 ### 2. 运行
 
 ```bash
-./showmethestory
+./show-me-the-story            # 数据保存在当前目录
+./show-me-the-story ~/novels   # 或指定一个数据目录
 ```
 
-程序启动后会自动检测 `config.json`：
-- 若不存在，自动生成空白默认配置并启动 Web UI
-- 若已存在，直接加载
+启动后访问 `http://localhost:48090`（端口可通过环境变量 `PORT` 修改）。
 
-访问 `http://localhost:8080`，在 Web UI 中配置 API 地址、模型和故事设定后即可开始创作。
+### 3. 配置 API
 
-### 3. 可选：手动配置
+首次进入会提示创建项目。创建后在「配置」页填写：
 
-也可手动创建 `config.json`：
+- **API 地址**：任意 OpenAI 兼容接口，如 `https://api.deepseek.com`、`http://localhost:11434/v1`（带不带 `/v1` 均可）
+- **模型名称**：如 `deepseek-chat`、`gpt-4o` 等
+- **API Key**：本地模型可留空
 
-```json
-{
-  "api_key": "your-api-key",
-  "base_url": "https://api.example.com/v1/",
-  "model": "gpt-4",
+API 配置全局共享，所有项目通用。
 
-  "story": {
-    "type": "奇幻/都市/科幻...",
-    "chapter_count": 20,
-    "target_words_per_chapter": 3000,
-    "writing_style": "你的写作风格要求...",
-    "character_setting": "角色设定...",
-    "world_setting": "世界观设定...",
-    "core_requirements": "核心写作要求..."
-  }
-}
-```
+### 4. 开始创作
 
-`prompts` 字段可留空（`{}`），程序会使用内置的默认提示词模板。如需自定义，可覆盖任意 prompt，支持的模板变量见下方说明。
+1. **配置故事**：在「配置」页填写故事类型、章节数、每章字数、写作风格等；角色 / 世界观 / 组织 / 关系可手动添加，也可点「AI 生成设定」让 AI 根据你的故事描述自动生成
+2. **生成大纲**：进入「大纲」页点击生成，AI 输出全书章节大纲；可整体提修订意见，也可逐章内联编辑，满意后确认
+3. **逐章写作**:「写作」页点击生成，AI 流式写出正文 → 自动摘要 → 自动事实核查 → 等你审核；确认进入下一章，或提修改意见让 AI 修订
+4. **想省事**：打开「自动确认」开关，AI 会自动逐章连写到底，期间可随时关闭
 
-## 配置说明
+## 核心功能说明
 
-### config.json 完整字段
+### 续写已有小说
 
-| 字段 | 类型 | 必填 | 说明 |
-|------|------|------|------|
-| `api_key` | string | 否 | API Key，本地模型可留空 |
-| `base_url` | string | 否 | OpenAI 兼容 API 地址，程序会自动补全 `/v1` |
-| `model` | string | 否 | 模型名称 |
-| `http_timeout_seconds` | int | 否 | HTTP 超时秒数，默认 300 |
-| `story.type` | string | 否 | 故事类型标签 |
-| `story.title` | string | 否 | 小说标题，留空则由 AI 生成 |
-| `story.chapter_count` | int | 否 | 章节数，默认 30 |
-| `story.target_words_per_chapter` | int | 否 | 每章目标字数，默认 2500 |
-| `story.writing_style` | string | 否 | 写作风格描述 |
-| `story.character_setting` | string | 否 | 角色设定 |
-| `story.world_setting` | string | 否 | 世界观设定 |
-| `story.core_requirements` | string | 否 | 核心写作要求 |
-| `prompts.*` | string | 否 | 自定义提示词模板，留空使用默认值 |
+在大纲页（空项目状态下）点「导入已有内容」，粘贴你已写好的文本。AI 会分析出标题、梗概、各章大纲与摘要，你确认导入后，已有章节标记为已完成，再点「生成后续大纲」即可接着往下写。
 
-### 自定义提示词模板
+### 伏笔系统
 
-`prompts` 下可覆盖以下 7 个模板：
-
-- `outline_generation` — 大纲生成
-- `chapter_writing` — 章节创作
-- `chapter_summary` — 摘要提炼
-- `fact_check` — 事实核查
-- `outline_revision` — 大纲修订
-- `foreshadow_planning` — 伏笔规划
-- `foreshadow_update` — 伏笔状态更新
-
-模板中使用 `{{.KeyName}}` 作为占位符，可用变量取决于具体模板：
-
-**outline_generation**：`StoryType`, `ChapterCount`, `TargetWords`, `WritingStyle`, `CharacterSetting`, `WorldSetting`, `CoreRequirements`
-
-**chapter_writing**：`Title`, `ChapterNum`, `CorePrompt`, `CoreRequirements`, `HistorySummary`, `Foreshadows`, `ChapterTitle`, `ChapterOutline`, `WritingStyle`, `CharacterSetting`, `WorldSetting`, `TargetWords`
-
-**chapter_summary**：`ChapterContent`
-
-**fact_check**：`HistorySummary`, `ChapterContent`
-
-**outline_revision**：`CurrentOutline`, `UserFeedback`, `LockedChapters`
-
-**foreshadow_planning**：`Title`, `CorePrompt`, `CoreRequirements`, `Outline`, `CharacterSetting`, `WorldSetting`
-
-**foreshadow_update**：`Title`, `ChapterNum`, `ChapterTitle`, `ChapterContent`, `HistorySummary`, `Foreshadows`, `CharacterSetting`, `WorldSetting`
-
-## 运行流程
-
-```
-启动
- │
- ├─ config.json 不存在？
- │   └─ 自动生成空白默认配置，提示用户通过 Web UI 配置 API
- │
- ├─ 检测 progress.json？
- │   ├─ 是 → 加载进度，跳转到对应阶段
- │   └─ 否 → 进入大纲阶段
- │
- ▼
-阶段一：大纲生成 (phase = "outline")
- │
- ├─ 调用 AI 生成大纲（标题、核心提示词、各章标题+大纲）
- ├─ 用户在 Web UI 审核大纲
- │   ├─ 确认 → 进入伏笔规划
- │   └─ 提出修改意见 → AI 修订后重新展示
- │
- ├─ [可选] 伏笔规划
- │   ├─ AI 根据大纲建议 3-8 条伏笔方案
- │   ├─ 用户在 Web UI 编辑、确认、删除伏笔
- │   └─ 确认后进入写作阶段
- │
- ▼
-阶段二：逐章创作 (phase = "writing")
- │
- └─ 对每一章（从 current_chapter_index 开始）：
-     ├─ 生成正文（注入前情摘要 + 活跃伏笔上下文）
-     ├─ 提炼本章摘要
-     ├─ 事实核查（FAIL 则自动重写，最多 3 次）
-     ├─ 自动更新伏笔状态（planted → progressing → resolved）
-     ├─ 伏笔超期告警（如有）
-     ├─ 保存 Chapter_XX.md
-     └─ 等待用户审核
-         ├─ 确认 → 锁定该章节，推进到下一章
-         └─ 提出修改意见 → AI 修改当前章节 + 修订后续大纲，重新审核
-```
-
-## 伏笔系统
-
-伏笔系统用于在长篇小说中管理叙事线索的埋设与回收，解决模型缺乏长期记忆的问题。
-
-### 工作原理
-
-1. **规划阶段**：大纲确认后，AI 分析完整大纲，建议 3-8 条伏笔方案（含埋设章节、预计回收章节）
-2. **写作注入**：每章写作时，所有活跃伏笔（planted/progressing）以结构化文本注入 prompt，包含描述、已有进展、回收建议
-3. **自动追踪**：每章完成后，AI 分析正文自动更新伏笔状态（新增进展、推进、回收）
-4. **超期告警**：若伏笔超过预计回收章节 3 章以上仍未回收，系统自动告警
-
-### 伏笔生命周期
+大纲确认后可让 AI 建议 3–8 条伏笔（含埋设章节和预计回收章节），也可手动创建。写作时活跃伏笔自动注入上下文；每章完成后 AI 自动更新伏笔状态：
 
 ```
 planted（已埋设）→ progressing（推进中）→ resolved（已回收）
-                                         → abandoned（已放弃）
+                                        → abandoned（已放弃）
 ```
 
-### API 端点
+伏笔超过预计回收章节 3 章仍未回收会自动告警。
 
-| 方法 | 路径 | 说明 |
+### 设定协调
+
+已经写了若干章之后修改了角色 / 世界观等关键设定？保存时程序会提示进行「设定协调」：AI 比对新设定与已写内容，输出兼容版设定，并基于新设定重新生成尚未写作章节的大纲，保证前后一致。
+
+### 技能（Skills）
+
+「技能」页可启用内置技能：
+
+| 技能 | 类型 | 作用 |
 |------|------|------|
-| `GET` | `/api/foreshadows` | 获取所有伏笔 |
-| `POST` | `/api/foreshadows/suggest` | AI 建议伏笔（异步，结果通过 SSE 推送） |
-| `POST` | `/api/foreshadows/confirm` | 批量确认 AI 建议的伏笔 |
-| `POST` | `/api/foreshadows` | 手动创建伏笔 |
-| `PUT` | `/api/foreshadows/{id}` | 更新伏笔 |
-| `DELETE` | `/api/foreshadows/{id}` | 删除伏笔 |
+| 中文去 AI 味 | 润色 | 23 条禁止模式 + 高频套话替换表 + 口语化规则 |
+| 故事去味检测 | 润色 | 6-Gate AI 味检测流程与真人写作基准 |
+| 写作技巧 | 写作 | 章首 / 章尾钩子、爽点密度、节奏控制 |
 
-## 断点恢复
+所有技能默认关闭，不会影响正常生成；启用润色类技能后，写作页的「去 AI 味」按钮可对章节做一键润色。也可在项目目录下放置自定义技能文件。
 
-程序在每个关键步骤后立即保存 `progress.json`。重新运行时：
+### AI 助理
 
-| 上次中断位置 | 恢复行为 |
-|-------------|---------|
-| 大纲生成中（未展示） | 重新生成大纲 |
-| 大纲等待用户确认 | 展示大纲，等待确认 |
-| 章节正在生成 (`status=writing`) | 重新生成该章节 |
-| 章节等待审核 (`status=review`) | 展示章节，等待审核 |
-| 章节已确认 (`status=accepted`) | 跳过，继续下一章 |
+右侧聊天面板（或「助理」页）提供一个能操作项目的 AI 助理：查设定、改角色、调大纲、修订章节等都可以通过对话完成。删除章节等破坏性操作需要 AI 先向你确认，且修改章节细节时只做最小化定向修订，不会推倒重写。
 
-## 输出文件
+## 数据与文件
 
-- `progress.json` — 完整的创作进度状态（含伏笔数据）
-- `config.json` — 运行时配置（可通过 Web UI 修改）
-- `Chapter_01.md`, `Chapter_02.md`, ... — 每章独立的 Markdown 文件，包含标题和摘要
-
-## 文件结构
+所有数据都是本地纯文本 / JSON 文件，目录结构：
 
 ```
-show-me-the-story/
-├── main.go              # 入口 + 流程分发
-├── config.go            # 配置结构体 + 加载 + 自动生成默认配置
-├── api.go               # OpenAI 兼容 API 调用 + 重试
-├── outline.go           # 大纲阶段：生成、修订
-├── writing.go           # 写作阶段：创作、核查、摘要、伏笔注入
-├── foreshadow.go        # 伏笔系统：建议、更新、注入、告警
-├── state.go             # 进度/伏笔结构体 + 读写持久化
-├── handlers.go          # HTTP API handlers
-├── web.go               # Web 服务器 + 路由
-├── logger.go            # SSE 日志广播
-├── prompts.go           # 提示词模板渲染 + 内置默认模板
-├── filesys.go           # 文件操作抽象
-├── static/              # 前端静态文件（内嵌）
-├── config.json          # 运行时配置（自动生成或手动创建）
-├── config.example.json  # 完整配置示例
-└── go.mod
+<数据目录>/
+├── api.json                 # API 配置（全局共享）
+└── storys/
+    └── <项目名>/
+        ├── config.json      # 故事配置 + 提示词 + 技能开关
+        ├── progress.json    # 创作进度、大纲、章节、伏笔
+        ├── settings.json    # 角色 / 世界观 / 组织 / 关系
+        ├── sessions/        # 助理聊天记录
+        └── Chapter_XX.md    # 每章正文（Markdown）
 ```
+
+想备份或迁移，直接复制整个数据目录即可。
 
 ## 注意事项
 
-- API 地址兼容各种格式：带/不带 `/v1`、带/不带尾部斜杠均可
-- 程序使用无限重试机制，网络故障时会自动等待并重试
-- 修改 `config.json` 中的 `story` 字段不会影响已生成的进度（程序使用快照）
-- 修改 `config.json` 中的 `prompts` 字段会在下次运行时生效
-- `*.json` 已被 `.gitignore` 排除，不会被版本控制
+- 同一时间只允许一个 AI 任务运行，任务进行中编辑操作会被暂时禁用，可随时点「停止」中断任务
+- 网络瞬时故障会自动重试（指数退避）；API Key 无效等致命错误会立即停止并提示
+- 高级用户可在 `config.json` 的 `prompts` 字段覆盖任意内置提示词模板（占位符格式为 `{{.KeyName}}`）
+
+---
+
+## 开发
+
+### 技术栈
+
+- **后端**：Go 1.25+，仅标准库，零第三方依赖
+- **前端**：Vite 5 + Svelte 4 + Tailwind CSS 4 + DaisyUI 5，构建产物通过 `embed.FS` 内嵌进二进制
+- **通信**：REST API + SSE 实时事件流
+
+### 编译
+
+需要 Go、Node.js 以及 [Task](https://taskfile.dev/)（可选）：
+
+```bash
+# 推荐：一键完整构建（前端 + 后端）
+task build
+
+# 或手动分步
+cd frontend && npm install && npm run build && cd ..
+go build -o show-me-the-story .
+```
+
+### 开发模式
+
+```bash
+task dev            # 编译并启动 Go 后端（:48090）
+task dev:frontend   # 启动 Vite dev server（:5173，热重载，代理 /api → :48090）
+```
+
+### 项目结构
+
+后端按职责拆分为单层 Go 文件（`outline.go` 大纲、`writing.go` 写作、`foreshadow.go` 伏笔、`agent.go` 助理 Agent Loop、`handlers.go` API 处理等），前端页面在 `frontend/src/pages/`。
+
+完整的架构说明、API 端点一览、SSE 事件类型、设计模式与开发约束请见 [AGENTS.md](AGENTS.md)。


### PR DESCRIPTION
## Summary

- 面向使用者重写 README：以首个公开发布版本的视角介绍功能、快速开始与核心功能说明，开发相关内容（技术栈/编译/项目结构）移至文末，深度技术细节统一指向 AGENTS.md
- 新增 `.github/workflows/release.yml`：在 main 分支推送 `v*` tag 时自动构建前端、交叉编译 5 个目标（linux/amd64、linux/arm64、windows/amd64、darwin/amd64、darwin/arm64）并创建 GitHub Release
  - tag 触发后校验 commit 在 origin/main 上，不在则跳过发布
  - 所有 action 使用当前最新稳定大版本（checkout@v6、setup-node@v6、setup-go@v6），Node 使用当前 Active LTS 24
  - 项目零 Go 依赖无 go.sum，setup-go 关闭缓存避免报错
  - 使用 runner 内置 gh CLI 创建 Release（--generate-notes），不引入第三方 action
- AGENTS.md 同步登记 workflow 条目

## Test plan

- [x] YAML 语法检查通过
- [x] 本地实测 windows/amd64 交叉编译成功（CGO_ENABLED=0）
- [ ] 合并到 main 后打 v* tag 验证完整发布流程

Made with [Cursor](https://cursor.com)