### PR TITLE
feat: API 配置测试连接按钮

### DIFF
--- a/frontend/src/pages/Config.svelte
+++ b/frontend/src/pages/Config.svelte
@@ -31,6 +31,7 @@
 
   let localApiCfg = { base_url: '', model: '', api_key: '', http_timeout_seconds: 300, context_budget_tokens: 900000 };
   let localStoryCfg = { type: '', title: '', chapter_count: 30, target_words_per_chapter: 2500, writing_style: '', story_synopsis: '' };
+  let testingApi = false;
 
   let apiCfgSnapshot = '';
   let storyCfgSnapshot = '';
@@ -97,6 +98,18 @@
       apiConfig.set({ ...localApiCfg });
       addToast('API 配置已保存', 'success');
     } catch (e) { addToast(e.message, 'error'); }
+  }
+
+  async function testAPIConfig() {
+    testingApi = true;
+    try {
+      const res = await api('POST', '/api/config/api/test', localApiCfg);
+      addToast(`连接成功！模型 ${res.model} 正常响应`, 'success');
+    } catch (e) {
+      addToast(e.message, 'error');
+    } finally {
+      testingApi = false;
+    }
   }
 
   // 直接保存故事配置（不经过 AI），存在已确认章节且关键设定有变化时提示协调
@@ -344,27 +357,34 @@
         <div class="grid grid-cols-2 gap-x-3 gap-y-1.5">
           <div class="col-span-2">
             <label class="text-xs text-base-content/50 mb-0.5 block">API Base URL</label>
-            <input type="text" class="input input-sm w-full" bind:value={localApiCfg.base_url} placeholder="https://api.example.com/v1/" disabled={$taskRunning} />
+            <input type="text" class="input input-sm w-full" bind:value={localApiCfg.base_url} placeholder="https://api.example.com/v1/" disabled={$taskRunning || testingApi} />
           </div>
           <div>
             <label class="text-xs text-base-content/50 mb-0.5 block">Model</label>
-            <input type="text" class="input input-sm w-full" bind:value={localApiCfg.model} placeholder="gpt-4" disabled={$taskRunning} />
+            <input type="text" class="input input-sm w-full" bind:value={localApiCfg.model} placeholder="gpt-4" disabled={$taskRunning || testingApi} />
           </div>
           <div>
             <label class="text-xs text-base-content/50 mb-0.5 block">HTTP 超时（秒）</label>
-            <input type="number" class="input input-sm w-full" bind:value={localApiCfg.http_timeout_seconds} disabled={$taskRunning} />
+            <input type="number" class="input input-sm w-full" bind:value={localApiCfg.http_timeout_seconds} disabled={$taskRunning || testingApi} />
           </div>
           <div class="col-span-2">
             <label class="text-xs text-base-content/50 mb-0.5 block">上下文预算（tokens）</label>
-            <input type="number" class="input input-sm w-full" bind:value={localApiCfg.context_budget_tokens} placeholder="900000" disabled={$taskRunning} title="全书优化时估算上下文用量，默认 900000（约 1M 模型）" />
+            <input type="number" class="input input-sm w-full" bind:value={localApiCfg.context_budget_tokens} placeholder="900000" disabled={$taskRunning || testingApi} title="全书优化时估算上下文用量，默认 900000（约 1M 模型）" />
           </div>
           <div class="col-span-2">
             <label class="text-xs text-base-content/50 mb-0.5 block">API Key</label>
-            <input type="password" class="input input-sm w-full" bind:value={localApiCfg.api_key} placeholder="sk-..." disabled={$taskRunning} />
+            <input type="password" class="input input-sm w-full" bind:value={localApiCfg.api_key} placeholder="sk-..." disabled={$taskRunning || testingApi} />
           </div>
         </div>
-        <div class="flex justify-end">
-          <button class="btn btn-primary btn-xs" on:click={saveAPIConfig} disabled={$taskRunning}>保存</button>
+        <div class="flex justify-end gap-2">
+          <button class="btn btn-outline btn-xs" on:click={testAPIConfig} disabled={$taskRunning || testingApi}>
+            {#if testingApi}
+              <span class="loading loading-spinner loading-xs"></span>测试中...
+            {:else}
+              测试连接
+            {/if}
+          </button>
+          <button class="btn btn-primary btn-xs" on:click={saveAPIConfig} disabled={$taskRunning || testingApi}>保存</button>
         </div>
       </div>
     </div>

--- a/handlers.go
+++ b/handlers.go
@@ -289,6 +289,48 @@ func (h *Handlers) PutAPIConfig(w http.ResponseWriter, r *http.Request) {
 	h.writeJSON(w, http.StatusOK, h.apiCfg)
 }
 
+func (h *Handlers) PostAPITest(w http.ResponseWriter, r *http.Request) {
+	if h.rejectIfTaskRunning(w) {
+		return
+	}
+	var testCfg APIConfig
+	if err := json.NewDecoder(r.Body).Decode(&testCfg); err != nil {
+		h.writeError(w, http.StatusBadRequest, "无效的JSON: "+err.Error())
+		return
+	}
+	if err := validateAPIConfig(&testCfg); err != nil {
+		h.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	resp, err := CallAPIMessages(ctx, &testCfg, []Message{
+		{Role: "user", Content: "Hi"},
+	})
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			h.writeError(w, http.StatusGatewayTimeout, "连接超时（15秒）")
+			return
+		}
+		h.writeError(w, http.StatusBadGateway, "测试失败: "+err.Error())
+		return
+	}
+
+	result := map[string]interface{}{
+		"success": true,
+		"message": "连接成功",
+		"model":   testCfg.Model,
+	}
+	if len(resp) > 100 {
+		result["sample"] = resp[:100] + "..."
+	} else {
+		result["sample"] = resp
+	}
+	h.writeJSON(w, http.StatusOK, result)
+}
+
 func (h *Handlers) GetConfig(w http.ResponseWriter, r *http.Request) {
 	h.writeJSON(w, http.StatusOK, h.cfg)
 }

--- a/web.go
+++ b/web.go
@@ -34,6 +34,7 @@ func startWebServer(apiCfg *APIConfig, apiCfgPath string, cfg *Config, state *Pr
 	// API config (global, always available)
 	mux.HandleFunc("GET /api/config/api", h.GetAPIConfig)
 	mux.HandleFunc("PUT /api/config/api", h.PutAPIConfig)
+	mux.HandleFunc("POST /api/config/api/test", h.PostAPITest)
 
 	// Project-scoped endpoints (require project selection)
 	mux.HandleFunc("GET /api/config", h.GetConfig)


### PR DESCRIPTION
## Summary
- 在 API 配置卡片中新增「测试连接」按钮，使用当前表单中的配置发送一条最简请求验证连通性
- 测试期间禁用所有输入框和按钮（含保存），带 spinner 加载态反馈
- 15 秒超时机制：超时返回 504，其他错误返回 502，成功时 toast 显示模型名称和响应片段