### PR TITLE
Add task-level token tracking and improve project creation UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ task dev                              # 编译并启动 Go 后端
 | `main.go` | 入口，确定程序目录（`progDir`），创建 `storys/` 目录，加载 API 配置，启动 Web 服务器（无项目选择状态） |
 | `config.go` | `APIConfig`（含 `ContextBudgetTokens` 全书优化上下文预算）、`Config`（含 `SkillConfig` + `Language`）、`StoryConfig`、`PromptsConfig` 结构体，Load/Save 函数，`DefaultConfigForLang(lang)`、`NormalizeLanguage`、`applyDefaults(lang)` 按语言选择默认 prompts |
 | `state.go` | `Progress`、`ChapterState`、`Foreshadow` 结构体，`LoadProgress`、`SaveProgress`（原子写入）、`ChapterMarkdownPath`、`SaveChapterMarkdown(projectDir, ...)`、`ForeshadowRoadmapPath`（项目目录 `Foreshadows.md`） |
-| `api.go` | `CallAPI`/`CallAPIMessages`（同步）、`CallAPIStream`/`CallAPIStreamMessages`（流式，支持完整多轮消息历史）、`CallAPIWithRetry`/`CallAPIWithRetryLog`（无限重试）、`CallAPIStreamWithRetry`/`CallAPIStreamWithRetryLog`，`validateAPIConfig`、`isFatalAPIError`（401/403/404 致命，网络超时可重试） |
+| `api.go` | `CallAPI`/`CallAPIMessages`（**内部优先流式缓冲**，失败时回退 `callAPIMessagesSync`）、`CallAPIStream`/`CallAPIStreamMessages`（流式，含 `stream_options.include_usage`）、`CallAPIWithRetry`/`CallAPIWithRetryLog`（无限重试）、`CallAPIStreamWithRetry`/`CallAPIStreamWithRetryLog`，`validateAPIConfig`、`isFatalAPIError`（401/403/404 致命，网络超时可重试）；所有调用经 `taskCtx` 时自动累计 token（优先 API `usage`，否则 rune 估算） |
 | `outline.go` | `generateOutline`、`reviseOutline`、`GenerateOutlineAction`（存在已确认章节时拒绝整体重新生成）、`ReviseOutlineAction`、`ConfirmOutlineAction`、`EditChapterOutline`、`cleanJSONResponse` |
 | `writing.go` | `GenerateChapterAction`（含写前大纲一致性检查，共 5 步；第 5 步更新伏笔并落盘 `Foreshadows.md`）、`ReviseChapterAction`/`ReviseSpecificChapterAction`（修订后同步更新伏笔）、`ConfirmChapterAction`、`PolishChapterAction`、`SmoothTransitionsAction`（批量优化已确认章节衔接，逐章最小化重写开头、逐章落盘）、`parseFactCheckResult`（JSON 优先 + 字符串 fallback）、`checkOutlineConsistency`（写前检查本章大纲与已写剧情冲突，冲突时最小化修订本章大纲）、章节内容生成/摘要/事实核查/流式输出、`buildHistorySummary`、`buildPreviousChapterTail`（上一章尾部约 800 字注入写作 prompt）、`buildOutlineConstraints`（全书章节脉络反向约束：后续 10 章大纲防提前出现 + 前文大纲防一次性事件重复，注入写作与事实核查 prompt）、`appendIfMissingPlaceholder`（老项目持久化旧模板缺新占位符时把上下文块追加到渲染结果末尾兜底）、`splitChapterOpening` |
 | `foreshadow.go` | `SuggestForeshadows`、`UpdateForeshadows`、伏笔格式化注入、伏笔告警、`BuildForeshadowRoadmapMarkdown`、`SaveForeshadowRoadmap`、`syncForeshadowsAfterChapter`、`NextForeshadowID` |
@@ -84,7 +84,8 @@ task dev                              # 编译并启动 Go 后端
 | `postprocess.go` | `PostProcessState`/`RoadmapItem` 结构体，`LoadPostProcess`/`SavePostProcess`（`postprocess.json`）、`buildPostProcessBundle`（设定+摘要+全文组装与长文策略：全文/摘要模式）、`DiagnoseBookAction`、`ConsistencyCheckBookAction`（超长书按卷分段）、`BuildRoadmapAction`、`FullPostProcessAnalyzeAction`（诊断→核查→路线图）、`ExecuteRoadmapAction`（可选前置衔接优化 + 逐条定向修订/润色 + diff 节选） |
 | `handlers.go` | `Handlers` 结构体（含项目管理字段 `progDir`/`projectName`/`projectMu`、自动确认开关 `autoConfirm`、`postprocess`/`postprocessPath`）、`projectDir()` 帮助函数、项目切换 `switchProject()`、`ensureProject()` 检查、`rejectIfTaskRunning()`（任务运行期间编辑类端点返回 409）、所有 HTTP handler（含 `PostChapterPolish` 单章去AI味、`PostChapterReviseSpecific` 定向修订、`PostChaptersSmoothTransitions` 批量衔接优化、全书优化 `GetPostProcess`/`PostPostProcessDiagnose`/`PostPostProcessConsistency`/`PostPostProcessRoadmap`/`PutPostProcessRoadmap`/`PostPostProcessExecute`/`DeletePostProcess`、`GetAutoConfirm`/`PutAutoConfirm`）、`PostChapterGenerate` 自动确认循环（开启时每章生成后自动确认并继续下一章）、`tryStartTask`/`endTask`/`startChildWork` 互斥、项目管理 handler（`GetProjects`/`PostProject`/`PostProjectSelect`/`GetProjectCurrent`/`DeleteProject`） |
 | `web.go` | 路由注册（含项目管理端点、`/api/autoconfirm`）、CORS/日志中间件、静态文件服务、`startWebServer`、项目管理 handler（`GetProjects`/`PostProject`/`GetProjectCurrent`/`PostProjectSelect`/`DeleteProject`） |
-| `logger.go` | `LogBroadcaster`（SSE 广播）、所有日志/事件方法（含 `ChatChunk`、`ToolCallStart`、`ToolCallEnd`、`StreamStart`、`StreamProgress`、`PolishResult`、`PostProcessReport`、`PostProcessRoadmap`、`PostProcessItemDone`、`PostProcessUpdate`）、`LogEntry.MsgEN` 可选英文版、`logBilingual` 与 `InfoBilingual`/`ErrorBilingual`/`WarnBilingual`/`SuccessBilingual` |
+| `logger.go` | `LogBroadcaster`（SSE 广播）、所有日志/事件方法（含 `ChatChunk`、`ToolCallStart`、`ToolCallEnd`、`StreamStart`、`TokenUsage`、`PolishResult`、`PostProcessReport`、`PostProcessRoadmap`、`PostProcessItemDone`、`PostProcessUpdate`）、`LogEntry.MsgEN` 可选英文版、`logBilingual` 与 `InfoBilingual`/`ErrorBilingual`/`WarnBilingual`/`SuccessBilingual` |
+| `tokens.go` | `TaskTokenUsage` 任务级 token 累计器（context 挂载）、`withTaskTokens`/`taskTokensFromContext`、throttled SSE 推送 |
 | `prompts.go` | `RenderPrompt`（`{{.KeyName}}` 替换）、`DefaultPromptsZH` 变量（所有内置中文提示词模板）、`DefaultPromptsForLang(lang)` |
 | `prompts_en.go` | `DefaultPromptsEN`：16 个 prompt 字段全量英文模板（与中文一一对应） |
 | `locale.go` | `LangZH`/`LangEN` 常量、`localeFromRequest` 从 `X-UI-Locale`/`Accept-Language`/`?locale=` 解析、`errorCatalog` 双语错误表、`T(lang, key, args)`、`systemPrompts` 内联 system prompt 集中表、`SystemPromptFor(lang, key)`、`Handlers.writeErrorReq` 本地化错误响应 |
@@ -107,15 +108,16 @@ task dev                              # 编译并启动 Go 后端
 | `src/App.svelte` | 根组件：Header（项目badge + 项目语言 badge ZH/EN + 「切换 / 新建项目」按钮（任务运行时禁用）+ 阶段badge + 章节进度badge + AI思考中badge + 右侧 UI 语言切换按钮中 / EN） + 顶部导航（配置/大纲/写作/伏笔/图谱/技能，带图标） + 页面路由 + LogPanel + Toast 容器；初始加载若有当前项目则 `setLocale(project.language)` |
 | `src/lib/api.js` | `api(method, url, body)` — fetch 封装，自动带 `X-UI-Locale`/`Accept-Language` 头，错误消息走 `translateServerMessage` |
 | `src/lib/router.js` | `currentPage` store + hash 路由监听 |
-| `src/lib/stores.js` | 全局 Svelte stores（progress、config、settings、postprocess、taskRunning、streamCharCount、autoConfirm、lastFailedTask、`projectLanguage` 等）+ toast/log 管理 |
+| `src/lib/stores.js` | 全局 Svelte stores（progress、config、settings、postprocess、taskRunning、taskTokenUsage、autoConfirm、lastFailedTask、`projectLanguage` 等）+ toast/log 管理 |
 | `src/lib/sse.js` | `connectSSE()` — EventSource 连接 URL 拼 `?locale=` + 多种事件处理 → 更新 stores；content_chunk/chat_chunk 按 150ms 节流缓冲批量刷入；章节流式全文只存模块级变量，`streamingContent` store 仅保留尾部窗口（约 3000 字符）；`refreshProgress()` 对 progress_update 拉取做 500ms 去抖（task_end 立即刷新）；stream_start 事件清空流式缓冲；`log` 事件优先用 `msg_en` 字段，否则 `translateServerMessage`；任务名通过 i18n `task.<name>` 翻译；全书优化 `postprocess_update`/`postprocess_roadmap`/`postprocess_item_done` 事件 |
 | `src/lib/markdown.js` | `renderMarkdown(text)` — marked 解析 + DOMPurify 清洗，供聊天气泡渲染 markdown |
 | `src/lib/i18n/index.js` | i18n 核心：`uiLocale` store（持久化到 `localStorage`）、`setLocale`/`getLocale`、`t` 派生 store（`$t('key', params)`，插值 `{name}`）、`translate` 命令式、`translateServerMessage(msg, lang)` 把后端中文映射到英文（含 errorCatalog 镜像 + 常见 log + 动态前缀） |
 | `src/lib/i18n/zh.js`, `en.js` | 扁平 key 字典；新增可见文案必须同时在两个文件加 key |
-| `src/pages/Projects.svelte` | 项目选择页：新建项目（含中文/English 语言下拉，POST 时携带 `language`）+ 项目列表（每项显示语言 badge，可选择/删除）；选中项目后 `setLocale(project.language)` |
+| `src/pages/Projects.svelte` | 项目选择页：新建项目（名称全宽 + 中文/EN 分段按钮选语言，POST 时携带 `language`）+ 项目列表（每项显示语言 badge，可选择/删除）；选中项目后 `setLocale(project.language)` |
 | `src/pages/Config.svelte` | 配置页：API 配置（含上下文预算 tokens）、故事配置（直接 PUT 保存 + 关键设定变更时提示协调）、角色管理、世界观管理、组织管理（卡片 + 成员勾选）、关系管理（卡片 + 源/目标实体选择）；任务运行时所有输入控件禁用 |
 | `src/pages/Outline.svelte` | 大纲页：直接操作按钮（生成/确认/修订意见/删除/生成后续大纲）+ 导入续写 + pending 章节内联编辑 + 流式预览 |
-| `src/pages/Writing.svelte` | 写作页：章节列表（状态点）+ 直接操作（生成/确认/修改意见/去AI味，自动区分当前章修订与定向修订）+ 自动确认模式开关（toggle，随时可开关）+ 伏笔追踪摘要卡片（活跃/超期/临近回收）+ 优化章节衔接（进度卡片工具栏小按钮，已确认 ≥ 2 章时显示）+ 导出 TXT + 复制 + 上下章导航 + 流式尾部窗口展示（含「仅显示最新内容」提示，字数用 streamCharCount）+ rAF 自动滚动（自动确认模式下自动跟随正在生成的章节）+ 全书完成后展示 `PostProcessPanel` |
+| `src/pages/Writing.svelte` | 写作页：章节列表（状态点）+ 直接操作（生成/确认/修改意见/去AI味，自动区分当前章修订与定向修订）+ 自动确认模式开关（toggle，随时可开关）+ 伏笔追踪摘要卡片（活跃/超期/临近回收）+ 优化章节衔接（进度卡片工具栏小按钮，已确认 ≥ 2 章时显示）+ 导出 TXT + 复制 + 上下章导航 + 流式尾部窗口展示（含「仅显示最新内容」提示；任务进行中当前章显示 taskTokenUsage，空闲时显示正文字数）+ rAF 自动滚动（自动确认模式下自动跟随正在生成的章节）+ 全书完成后展示 `PostProcessPanel` |
+| `src/components/TaskTokenBadge.svelte` | 任务 token 展示组件（`↑ prompt ↓ completion tokens`），供 ChatPanel / App 顶栏 / Writing 页复用 |
 | `src/pages/Foreshadows.svelte` | 伏笔页：统计概览 + AI 设计伏笔 + 手动 CRUD + AI 建议确认面板（SSE `foreshadow_suggestions`）+ 列表/章节时间线/路线图文档三视图 + 复制/下载 `Foreshadows.md` |
 | `src/components/PostProcessPanel.svelte` | 全书优化面板：开始全书分析（诊断+核查+路线图）/ 重新核查 / 重新生成路线图 / 清空；诊断与核查报告 Markdown 展示；优化工单表格（勾选、编辑意见、执行选项、diff 对比弹窗） |
 | `src/pages/Relations.svelte` | 图谱页：Canvas 力导向图谱（ForceGraph 类），支持拖拽、滚轮缩放（以光标为中心，0.3x–3x）、hover 高亮（强调 hover 节点与其连线，次强调直接相邻节点，其余淡化） |
@@ -179,7 +181,7 @@ func (h *Handlers) PostXxxAction(w http.ResponseWriter, r *http.Request) {
 
 ### 自动确认模式
 
-`Handlers.autoConfirm`（`taskMu` 保护）为运行时开关，不持久化。`GET/PUT /api/autoconfirm` 读取/切换，任务运行期间也可随时开关。开启后 `PostChapterGenerate` 的任务 goroutine 进入循环：生成章节 → 若开关仍开启则 `ConfirmChapterAction` 自动确认 → 继续生成下一章，直到全部完成、开关被关闭（当前章生成完后停在 review 状态）、任务被取消或出错。整个循环在同一个任务锁内执行，期间仍受任务互斥保护。`GET /api/status` 返回 `auto_confirm` 字段。前端开关位于写作页进度卡片（toggle），开启时流式输出自动跟随正在生成的章节。
+`Handlers.autoConfirm`（`taskMu` 保护）为运行时开关，不持久化。`GET/PUT /api/autoconfirm` 读取/切换，任务运行期间也可随时开关。开启后 `PostChapterGenerate` 的任务 goroutine 进入循环：生成章节 → 若开关仍开启则 `ConfirmChapterAction` 自动确认 → 继续生成下一章，直到全部完成、开关被关闭（当前章生成完后停在 review 状态）、任务被取消或出错。整个循环在同一个任务锁内执行，期间仍受任务互斥保护。`GET /api/status` 返回 `auto_confirm` 及任务运行中的 `token_usage` 字段。前端开关位于写作页进度卡片（toggle），开启时流式输出自动跟随正在生成的章节。
 
 ### 流式输出节流 + 尾部窗口（前端性能）
 
@@ -188,9 +190,8 @@ func (h *Handlers) PostXxxAction(w http.ResponseWriter, r *http.Request) {
 - **节流缓冲**：`sse.js` 将 chunk 先累积到本地缓冲区，每 150ms 批量刷入 store
 - **尾部窗口**：章节流式全文只存 `sse.js` 模块级变量，`streamingContent` store 仅保留尾部约 3000 字符，每次刷新渲染成本恒定；写作页流式期间显示「仅显示最新内容」提示，生成结束后由 progress 重新拉取展示全文
 - **rAF 滚动**：写作页自动滚动合并到 `requestAnimationFrame`，每帧最多一次
-- **流式字数**：流式期间字数显示用 `streamCharCount` store（SSE 累计），不对全文做正则统计
+- **任务 token 追踪**：`tryStartTask()` 将 `TaskTokenUsage` 挂到 `taskCtx`；`api.go` 每次 LLM 调用累计 prompt/completion（优先 API `usage`，否则 rune×1.5 估算）；throttled SSE `token_usage`（约 2s）+ 前端每 2s poll `GET /api/status` 兜底；ChatPanel 任务栏、App 顶栏「AI思考中」、Writing 当前章均展示 `↑ ↓ tokens`
 - **progress 去抖**：`progress_update` 事件触发的 `/api/progress` 拉取（含全书正文的大 JSON）500ms 内合并为一次，`task_end` 时立即刷新
-- **聊天面板滚动守卫**：`ChatPanel` 的 `afterUpdate` 仅在消息区内容实际变化时才写 `scrollTop`，`streamCharCount` 跳动不触发重排
 
 `stream_start` 事件（每次章节流式输出开始时由后端发出）会清空缓冲与已生成字数计数，避免事实核查重试或自动连写时新旧内容叠加。
 
@@ -245,7 +246,7 @@ API 配置（`APIConfig`）与故事配置（`Config`）完全分离，分别保
 
 ### 流式输出
 
-`CallAPIStream` 返回流式响应，通过 `onChunk` 回调实时推送每个 token。`ContentChunk` SSE 事件用于前端实时渲染，`StreamProgress` 事件用于日志面板显示字符数进度（每 500 字触发一次）。
+`CallAPIStream` 返回流式响应，通过 `onChunk` 回调实时推送每个 token。`ContentChunk` SSE 事件用于前端实时渲染；token 累计经 `TaskTokenUsage` 推送 `token_usage` SSE（约 2s 节流）。
 
 ### 大纲反向约束 + 写前一致性检查
 
@@ -426,7 +427,7 @@ pending → writing → review → accepted
 | `progress_update` | `{phase, title, current_chapter, total_chapters, ...}` | 进度变化 |
 | `stream_start` | `{chapter_idx}` | 一次新的章节流式输出开始（前端清空流式缓冲，避免事实核查重试/自动连写时内容叠加） |
 | `content_chunk` | `{chapter_idx, text}` | 流式生成 token |
-| `stream_progress` | `{chapter_idx, char_count}` | 流式生成字符数进度（每 500 字） |
+| `token_usage` | `{prompt_tokens, completion_tokens}` | 任务级 token 累计（约 2s 节流；含流式与非流式步骤） |
 | `foreshadow_suggestions` | `ForeshadowSuggestion[]` | 伏笔建议结果 |
 | `continue_analysis` | `ContinueAnalysis` | 续写分析结果 |
 | `settings_reconciled` | `{explanation, changed_fields}` | 设定协调完成 |
@@ -501,10 +502,10 @@ Skill 文件格式：YAML frontmatter（`---` 分隔，含 `lang: zh|en`，无 `
 前端使用 Vite 5 + Svelte 4 + Tailwind CSS 4 + DaisyUI 5 构建，产物输出到 `frontend/dist/`，通过 `//go:embed frontend/dist` 内嵌到 Go 二进制。主题使用 xianii 暗色主题（定义在 `src/app.css` 的 `@plugin "daisyui/theme"` 块中）。
 
 - **页面**：`config`（配置直接保存 + 角色管理 + 世界观管理 + 组织管理（卡片 + 角色成员勾选）+ 关系管理（卡片 + 源/目标实体下拉，实体覆盖角色/组织/世界观，值编码为 `type:id`））、`outline`（大纲直接操作 + 内联编辑 + 导入续写）、`writing`（写作直接操作 + 定向修订 + 自动确认模式开关 + 伏笔追踪摘要 + 导出 TXT）、`foreshadows`（伏笔 CRUD + AI 建议确认 + 列表/时间线/路线图三视图）、`relations`（关系图谱 Canvas）、`skills`（技能管理）
-- **状态管理**：Svelte stores（`src/lib/stores.js`），包含 progress、config、settings、taskRunning、streamCharCount（流式已生成字数）、autoConfirm（自动确认模式）、foreshadowSuggestions/foreshadowShowSuggestions（AI 伏笔建议待确认）等全局状态
+- **状态管理**：Svelte stores（`src/lib/stores.js`），包含 progress、config、settings、taskRunning、taskTokenUsage（任务 token 累计）、autoConfirm（自动确认模式）、foreshadowSuggestions/foreshadowShowSuggestions（AI 伏笔建议待确认）等全局状态
 - **路由**：hash 路由（`src/lib/router.js`），`currentPage` store + `window.hashchange` 监听
 - **API 调用**：`api(method, url, body)` 封装 fetch（`src/lib/api.js`）
-- **SSE**：`connectSSE()` 建立 EventSource 连接，13 种事件类型自动更新 stores（`src/lib/sse.js`）；content_chunk/chat_chunk 经 150ms 节流缓冲批量刷入；任务成功完成以 toast 提示（不弹全屏遮罩）
+- **SSE**：`connectSSE()` 建立 EventSource 连接，14 种事件类型自动更新 stores（`src/lib/sse.js`）；content_chunk/chat_chunk 经 150ms 节流缓冲批量刷入；`token_usage` 更新 taskTokenUsage，任务运行中每 2s poll `/api/status` 兜底；任务成功完成以 toast 提示（不弹全屏遮罩）
 - **Markdown 渲染**：助理消息通过 `src/lib/markdown.js`（marked + DOMPurify）渲染为 HTML，样式在 `app.css` 的 `.md-body` 块中定义
 - **开发模式**：`task dev:frontend` 启动 Vite dev server（端口 5173），代理 `/api` → `:48090`，支持 HMR 热重载
 - **关系图谱**：`ForceGraph` 类，纯 Canvas 力导向布局，支持拖拽节点、滚轮缩放（以光标为中心）、悬浮 tooltip 与 hover 高亮（hover 节点及连线强调、相邻节点次强调、无关元素淡化）
@@ -542,7 +543,7 @@ Skill 文件格式：YAML frontmatter（`---` 分隔，含 `lang: zh|en`，无 `
 - [`frontend/src/lib/sse.js`](frontend/src/lib/sse.js)：EventSource URL 拼 `?locale=`，`log` 事件优先用 `msg_en`，回退 `translateServerMessage`；任务名通过 `task.<name>` key 翻译
 - [`frontend/src/lib/stores.js`](frontend/src/lib/stores.js)：新增 `projectLanguage` writable
 - [`frontend/src/App.svelte`](frontend/src/App.svelte)：Header 显示项目语言 badge（ZH/EN）+ UI 语言切换按钮（中 / EN）；选择/创建项目后自动 `setLocale(project.language)`
-- [`frontend/src/pages/Projects.svelte`](frontend/src/pages/Projects.svelte)：新建项目表单含语言下拉（中文 / English），POST 时携带 `language`；列表项显示语言 badge
+- [`frontend/src/pages/Projects.svelte`](frontend/src/pages/Projects.svelte)：新建项目表单名称全宽 + 中文/EN 分段按钮选语言，POST 时携带 `language`；列表项显示语言 badge
 
 ### 老项目兼容
 

--- a/api.go
+++ b/api.go
@@ -13,9 +13,20 @@ import (
 )
 
 type ChatRequest struct {
-	Model    string    `json:"model"`
-	Messages []Message `json:"messages"`
-	Stream   bool      `json:"stream,omitempty"`
+	Model         string         `json:"model"`
+	Messages      []Message      `json:"messages"`
+	Stream        bool           `json:"stream,omitempty"`
+	StreamOptions *streamOptions `json:"stream_options,omitempty"`
+}
+
+type streamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
+type tokenUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
 }
 
 type Message struct {
@@ -27,6 +38,7 @@ type ChatResponse struct {
 	Choices []struct {
 		Message Message `json:"message"`
 	} `json:"choices"`
+	Usage *tokenUsage `json:"usage,omitempty"`
 }
 
 func normalizeURL(base string) string {
@@ -81,9 +93,34 @@ func CallAPI(ctx context.Context, apiCfg *APIConfig, system, user string) (strin
 	})
 }
 
-// CallAPIMessages 以完整的多轮消息数组调用 API（非流式）。
+// CallAPIMessages 以完整的多轮消息数组调用 API。
+// 内部优先走流式并缓冲全文，使 token 计数在等待期间也能更新；流式不可用时回退同步请求。
 func CallAPIMessages(ctx context.Context, apiCfg *APIConfig, messages []Message) (string, error) {
+	result, err := CallAPIStreamMessages(ctx, apiCfg, messages, nil)
+	if err == nil && result != "" {
+		return result, nil
+	}
+	if ctx.Err() != nil {
+		if result != "" {
+			return result, ctx.Err()
+		}
+		return "", ctx.Err()
+	}
+	if result != "" {
+		return result, err
+	}
+	if err != nil && isFatalAPIError(err) {
+		return "", err
+	}
+	// ponytail: fallback for providers with broken stream; loses in-flight stream estimate only.
+	return callAPIMessagesSync(ctx, apiCfg, messages)
+}
+
+// callAPIMessagesSync 同步 HTTP 调用（仅作流式失败时的回退）。
+func callAPIMessagesSync(ctx context.Context, apiCfg *APIConfig, messages []Message) (string, error) {
 	fullURL := normalizeURL(apiCfg.BaseURL)
+	tracker := taskTokensFromContext(ctx)
+	tracker.beginCall(messages)
 
 	reqBody := ChatRequest{
 		Model:    apiCfg.Model,
@@ -128,7 +165,15 @@ func CallAPIMessages(ctx context.Context, apiCfg *APIConfig, messages []Message)
 	}
 
 	if len(chatResp.Choices) > 0 {
-		return chatResp.Choices[0].Message.Content, nil
+		content := chatResp.Choices[0].Message.Content
+		if tracker != nil {
+			if chatResp.Usage != nil {
+				tracker.finishCall(chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, true, messages, content)
+			} else {
+				tracker.finishCall(0, 0, false, messages, content)
+			}
+		}
+		return content, nil
 	}
 	return "", fmt.Errorf("接口未响应有效 Choices 文本")
 }
@@ -198,6 +243,7 @@ type streamDelta struct {
 			Content string `json:"content"`
 		} `json:"delta"`
 	} `json:"choices"`
+	Usage *tokenUsage `json:"usage,omitempty"`
 }
 
 func CallAPIStream(ctx context.Context, apiCfg *APIConfig, system, user string, onChunk func(string)) (string, error) {
@@ -210,11 +256,14 @@ func CallAPIStream(ctx context.Context, apiCfg *APIConfig, system, user string, 
 // CallAPIStreamMessages 以完整的多轮消息数组调用 API（流式）。
 func CallAPIStreamMessages(ctx context.Context, apiCfg *APIConfig, messages []Message, onChunk func(string)) (string, error) {
 	fullURL := normalizeURL(apiCfg.BaseURL)
+	tracker := taskTokensFromContext(ctx)
+	tracker.beginCall(messages)
 
 	reqBody := ChatRequest{
 		Model:    apiCfg.Model,
 		Messages: messages,
 		Stream:   true,
+		StreamOptions: &streamOptions{IncludeUsage: true},
 	}
 
 	bts, err := json.Marshal(reqBody)
@@ -247,6 +296,7 @@ func CallAPIStreamMessages(ctx context.Context, apiCfg *APIConfig, messages []Me
 
 	var fullContent strings.Builder
 	scanner := bufio.NewScanner(resp.Body)
+	var streamUsage *tokenUsage
 
 	for scanner.Scan() {
 		if ctx.Err() != nil {
@@ -265,9 +315,15 @@ func CallAPIStreamMessages(ctx context.Context, apiCfg *APIConfig, messages []Me
 		if err := json.Unmarshal([]byte(data), &delta); err != nil {
 			continue
 		}
+		if delta.Usage != nil {
+			streamUsage = delta.Usage
+		}
 		if len(delta.Choices) > 0 && delta.Choices[0].Delta.Content != "" {
 			chunk := delta.Choices[0].Delta.Content
 			fullContent.WriteString(chunk)
+			if tracker != nil {
+				tracker.updateStreamContent(fullContent.String())
+			}
 			if onChunk != nil {
 				onChunk(chunk)
 			}
@@ -277,6 +333,13 @@ func CallAPIStreamMessages(ctx context.Context, apiCfg *APIConfig, messages []Me
 	result := fullContent.String()
 	if result == "" {
 		return "", fmt.Errorf("流式响应为空")
+	}
+	if tracker != nil {
+		if streamUsage != nil {
+			tracker.finishCall(streamUsage.PromptTokens, streamUsage.CompletionTokens, true, messages, result)
+		} else {
+			tracker.finishCall(0, 0, false, messages, result)
+		}
 	}
 	return result, nil
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -5,6 +5,7 @@
   import { api } from './lib/api.js';
   import { onMount } from 'svelte';
   import { t, uiLocale, setLocale } from './lib/i18n/index.js';
+  import TaskTokenBadge from './components/TaskTokenBadge.svelte';
   import Projects from './pages/Projects.svelte';
   import Config from './pages/Config.svelte';
   import Outline from './pages/Outline.svelte';
@@ -87,6 +88,7 @@
         <span class="badge badge-sm badge-warning gap-1">
           <span class="loading loading-spinner loading-xs"></span>
           {$t('app.aiThinking')}
+          <TaskTokenBadge className="badge badge-xs badge-warning font-mono border-0" />
         </span>
       {/if}
     {/if}

--- a/frontend/src/components/ChatPanel.svelte
+++ b/frontend/src/components/ChatPanel.svelte
@@ -2,8 +2,9 @@
   import { onMount, afterUpdate } from 'svelte';
   import { api } from '../lib/api.js';
   import { renderMarkdown } from '../lib/markdown.js';
-  import { chatSessions, currentChatSession, addToast, showConfirm, taskRunning, lastFailedTask, logEntries, currentTaskName, streamCharCount } from '../lib/stores.js';
+  import { chatSessions, currentChatSession, addToast, showConfirm, taskRunning, lastFailedTask, logEntries, currentTaskName } from '../lib/stores.js';
   import { t, uiLocale } from '../lib/i18n/index.js';
+  import TaskTokenBadge from './TaskTokenBadge.svelte';
 
   export let contextPage = 'config';
 
@@ -110,7 +111,7 @@
     autoScroll = nearBottom;
   }
 
-  // 滚动守卫：afterUpdate 在任何 store 变化（如 streamCharCount 每 150ms 跳动、
+  // 滚动守卫：afterUpdate 在任何 store 变化（如 token 计数、
   // 日志追加）后都会触发，无条件写 scrollTop 会造成高频强制重排。
   // 仅在消息区内容实际变化时才滚动。
   let lastScrollKey = '';
@@ -284,8 +285,8 @@
           <span class="text-success text-xs">●</span>
         {/if}
         <span class="text-xs font-semibold text-base-content/70">{$currentTaskName || $t('chat.task.placeholder')}{$taskRunning ? $t('chat.task.running') : $t('chat.task.ended')}</span>
-        {#if $taskRunning && $streamCharCount > 0}
-          <span class="badge badge-xs badge-info gap-1 font-mono">{$t('chat.task.wordCount', { n: $streamCharCount.toLocaleString() })}</span>
+        {#if $taskRunning}
+          <TaskTokenBadge />
         {/if}
         <span class="text-xs text-base-content/40 ml-auto">{taskStatusCollapsed ? $t('chat.task.expand') : $t('chat.task.collapse')}</span>
       </div>

--- a/frontend/src/components/TaskTokenBadge.svelte
+++ b/frontend/src/components/TaskTokenBadge.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { taskTokenUsage } from '../lib/stores.js';
+  import { t } from '../lib/i18n/index.js';
+
+  export let className = 'badge badge-xs badge-info gap-1 font-mono';
+</script>
+
+{#if $taskTokenUsage}
+  <span class={className}>
+    {$t('task.tokens.usage', {
+      prompt: $taskTokenUsage.prompt_tokens.toLocaleString(),
+      completion: $taskTokenUsage.completion_tokens.toLocaleString(),
+    })}
+  </span>
+{/if}

--- a/frontend/src/lib/i18n/en.js
+++ b/frontend/src/lib/i18n/en.js
@@ -400,7 +400,7 @@ export default {
   'chat.task.ended': ' ended',
   'chat.task.expand': 'Expand ▾',
   'chat.task.collapse': 'Collapse ▴',
-  'chat.task.wordCount': '{n} chars generated',
+  'task.tokens.usage': '↑ {prompt} ↓ {completion} tokens',
   'chat.notSelected': 'Select or create a session to start chatting',
   'chat.welcome.hint': 'I am the writing assistant. I can manage settings, generate outlines and write chapters for you.',
   'chat.welcome.q1': 'Help me refine the story settings',

--- a/frontend/src/lib/i18n/zh.js
+++ b/frontend/src/lib/i18n/zh.js
@@ -404,7 +404,7 @@ export default {
   'chat.task.ended': ' 已结束',
   'chat.task.expand': '展开 ▾',
   'chat.task.collapse': '收起 ▴',
-  'chat.task.wordCount': '已生成 {n} 字',
+  'task.tokens.usage': '↑ {prompt} ↓ {completion} tokens',
   'chat.notSelected': '选择或创建一个会话开始对话',
   'chat.welcome.hint': '我是创作助理，可以帮你管理设定、生成大纲和章节。',
   'chat.welcome.q1': '帮我完善故事设定',

--- a/frontend/src/lib/sse.js
+++ b/frontend/src/lib/sse.js
@@ -1,17 +1,15 @@
-import { addLog, addToast, config, progress, taskRunning, streamingContent, streamingChapterIdx, streamCharCount, continueAnalysis, currentChatSession, settings, chatSessions, lastFailedTask, currentTaskName, logEntries, postprocess, foreshadowSuggestions, foreshadowShowSuggestions } from './stores.js';
+import { get } from 'svelte/store';
+import { addLog, addToast, config, progress, taskRunning, streamingContent, streamingChapterIdx, taskTokenUsage, continueAnalysis, currentChatSession, settings, chatSessions, lastFailedTask, currentTaskName, logEntries, postprocess, foreshadowSuggestions, foreshadowShowSuggestions } from './stores.js';
 import { api } from './api.js';
 import { getLocale, translate, translateServerMessage } from './i18n/index.js';
 
 let eventSource = null;
 let reconnectTimer = null;
+let tokenPollTimer = null;
 
 // —— 流式输出节流缓冲 + 尾部窗口 ——
-// 节流只能降低更新频率，但若 store 中保存完整流式全文，每次刷新仍要对全文
-// 重新渲染/排版（成本随长度线性增长，总成本 O(n²)），长章节会把主线程占满
-// 直至页面无响应。因此完整文本只存模块级变量，store 仅保留尾部窗口，
-// 每次刷新渲染成本恒定 O(1)。生成结束后由 progress 重新拉取展示全文。
 const FLUSH_INTERVAL = 150;
-const TAIL_MAX = 3000; // store 中保留的尾部窗口字符数
+const TAIL_MAX = 3000;
 
 let contentBuf = '';
 let contentFull = '';
@@ -26,7 +24,6 @@ function flushContentBuf() {
   contentFull += text;
   streamingChapterIdx.set(contentIdx);
   streamingContent.set(contentFull.length > TAIL_MAX ? contentFull.slice(-TAIL_MAX) : contentFull);
-  streamCharCount.update(n => n + Array.from(text).length);
 }
 
 function resetContentStream(idx) {
@@ -36,12 +33,8 @@ function resetContentStream(idx) {
   contentIdx = idx;
   streamingChapterIdx.set(idx);
   streamingContent.set('');
-  streamCharCount.set(0);
 }
 
-// —— progress 拉取去抖 ——
-// progress_update 事件可能在短时间内连发，而 /api/progress 返回含全书正文的
-// 大 JSON，每次都拉取会造成解析 + 整页重渲染的尖峰。这里 500ms 内合并为一次。
 let progressFetchTimer = null;
 
 function refreshProgress(immediate = false) {
@@ -57,6 +50,23 @@ function refreshProgress(immediate = false) {
   }, 500);
 }
 
+function refreshTokenUsage() {
+  if (!get(taskRunning)) return;
+  api('GET', '/api/status').then(s => {
+    if (s?.token_usage) taskTokenUsage.set(s.token_usage);
+  }).catch(() => {});
+}
+
+function startTokenPoll() {
+  stopTokenPoll();
+  refreshTokenUsage();
+  tokenPollTimer = setInterval(refreshTokenUsage, 2000);
+}
+
+function stopTokenPoll() {
+  if (tokenPollTimer) { clearInterval(tokenPollTimer); tokenPollTimer = null; }
+}
+
 let chatBuf = '';
 let chatSessionId = null;
 let chatTimer = null;
@@ -67,7 +77,6 @@ function flushChatBuf() {
   const text = chatBuf;
   const sid = chatSessionId;
   chatBuf = '';
-  streamCharCount.update(n => n + Array.from(text).length);
   currentChatSession.update(s => {
     if (!s || s.id !== sid) return s;
     return { ...s, streaming_text: (s.streaming_text || '') + text };
@@ -86,8 +95,6 @@ export function connectSSE() {
 
   eventSource.addEventListener('log', e => {
     const d = JSON.parse(e.data);
-    // Prefer the server-supplied English text when UI is English; otherwise
-    // try the client-side dictionary; fall back to the Chinese original.
     if (locale === 'en') {
       d.msg = d.msg_en || translateServerMessage(d.msg, 'en');
     }
@@ -107,10 +114,11 @@ export function connectSSE() {
     taskRunning.set(true);
     resetContentStream(-1);
     clearChatBuf();
-    streamCharCount.set(0);
+    taskTokenUsage.set(null);
     currentTaskName.set(taskLabel(d.task));
     logEntries.set([]);
     lastFailedTask.set(null);
+    startTokenPoll();
   });
 
   eventSource.addEventListener('task_end', e => {
@@ -118,15 +126,15 @@ export function connectSSE() {
     taskRunning.set(false);
     resetContentStream(-1);
     clearChatBuf();
-    streamCharCount.set(0);
+    taskTokenUsage.set(null);
     currentTaskName.set(null);
+    stopTokenPoll();
     refreshProgress(true);
 
     if (d.success) {
       const name = taskLabel(d.task);
       addToast(translate('toast.taskDone', { name }), 'success');
     } else {
-      // 任务失败时记录重试信息
       lastFailedTask.set({ task: d.task, taskName: taskLabel(d.task) });
     }
 
@@ -152,8 +160,11 @@ export function connectSSE() {
     }
   });
 
-  // 一次新的流式输出开始（章节生成/修订/润色），清空旧缓冲，
-  // 避免事实核查重试或自动连写时新旧内容叠加。
+  eventSource.addEventListener('token_usage', e => {
+    const d = JSON.parse(e.data);
+    taskTokenUsage.set(d);
+  });
+
   eventSource.addEventListener('stream_start', e => {
     const d = JSON.parse(e.data);
     resetContentStream(d.chapter_idx);
@@ -167,15 +178,6 @@ export function connectSSE() {
     }
     contentBuf += d.text;
     if (!contentTimer) contentTimer = setTimeout(flushContentBuf, FLUSH_INTERVAL);
-  });
-
-  eventSource.addEventListener('stream_progress', e => {
-    const d = JSON.parse(e.data);
-    addLog({
-      level: 'info',
-      msg: translate('log.streamProgress', { chars: d.char_count }),
-      time: new Date().toLocaleTimeString(getLocale() === 'en' ? 'en-US' : 'zh-CN', { hour12: false }),
-    });
   });
 
   eventSource.addEventListener('continue_analysis', e => {

--- a/frontend/src/lib/stores.js
+++ b/frontend/src/lib/stores.js
@@ -21,8 +21,8 @@ export const selectedChapter = writable(-1);
 
 export const streamingContent = writable('');
 export const streamingChapterIdx = writable(-1);
-// 当前任务流式输出累计字数（章节正文 + 助理回复）
-export const streamCharCount = writable(0);
+// 当前任务累计 token（提交/返回），由 SSE token_usage 更新
+export const taskTokenUsage = writable(null);
 // 自动确认模式（每章生成完成后自动确认并继续下一章）
 export const autoConfirm = writable(false);
 

--- a/frontend/src/pages/Projects.svelte
+++ b/frontend/src/pages/Projects.svelte
@@ -88,7 +88,7 @@
 </script>
 
 <div class="flex items-center justify-center min-h-[60vh]">
-  <div class="w-full max-w-lg space-y-6">
+  <div class="w-full max-w-xl space-y-6">
     <!-- Title -->
     <div class="text-center">
       <div class="text-5xl mb-4">📚</div>
@@ -100,19 +100,34 @@
     <div class="card bg-base-200 shadow-sm">
       <div class="card-body p-4">
         <h3 class="card-title text-sm">{$t('projects.create')}</h3>
-        <div class="flex gap-2">
-          <input
-            type="text"
-            class="input input-sm flex-1"
-            bind:value={newProjectName}
-            placeholder={$t('projects.create.placeholder')}
-            on:keydown={handleKeydown}
-            disabled={creating}
-          />
-          <select class="select select-sm" bind:value={newProjectLang} disabled={creating} title={$t('projects.create.lang')}>
-            <option value="zh">中文</option>
-            <option value="en">English</option>
-          </select>
+        <input
+          type="text"
+          class="input input-sm w-full"
+          bind:value={newProjectName}
+          placeholder={$t('projects.create.placeholder')}
+          on:keydown={handleKeydown}
+          disabled={creating}
+        />
+        <div class="flex items-center justify-between gap-3">
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-base-content/50">{$t('projects.create.lang')}</span>
+            <div class="join">
+              <button
+                type="button"
+                class="btn btn-sm join-item"
+                class:btn-active={newProjectLang === 'zh'}
+                disabled={creating}
+                on:click={() => newProjectLang = 'zh'}
+              >中文</button>
+              <button
+                type="button"
+                class="btn btn-sm join-item"
+                class:btn-active={newProjectLang === 'en'}
+                disabled={creating}
+                on:click={() => newProjectLang = 'en'}
+              >EN</button>
+            </div>
+          </div>
           <button
             class="btn btn-primary btn-sm"
             on:click={createProject}

--- a/frontend/src/pages/Writing.svelte
+++ b/frontend/src/pages/Writing.svelte
@@ -1,9 +1,10 @@
 <script>
   import { onMount } from 'svelte';
   import { api } from '../lib/api.js';
-  import { progress, taskRunning, streamingContent, streamingChapterIdx, streamCharCount, selectedChapter, autoConfirm, addToast, confirmModal } from '../lib/stores.js';
+  import { progress, taskRunning, streamingContent, streamingChapterIdx, selectedChapter, autoConfirm, addToast, confirmModal } from '../lib/stores.js';
   import { t } from '../lib/i18n/index.js';
   import PostProcessPanel from '../components/PostProcessPanel.svelte';
+  import TaskTokenBadge from '../components/TaskTokenBadge.svelte';
 
   // 保留 prop 以兼容 App 传参
   export let sendToChat = async () => {};
@@ -54,8 +55,8 @@
   $: isStreamingThis = $streamingChapterIdx === $selectedChapter && $streamingContent;
   // 流式期间 $streamingContent 只含尾部窗口（性能保护），全文在生成结束后由 progress 拉取
   $: displayContent = isStreamingThis ? $streamingContent : (ch?.content || '');
-  // 流式期间不对全文做正则统计，直接用 SSE 累计的字数
-  $: wordCount = isStreamingThis ? $streamCharCount : (ch?.content ? ch.content.replace(/\s/g, '').length : 0);
+  $: chapterWordCount = ch?.content ? ch.content.replace(/\s/g, '').length : 0;
+  $: showTaskTokens = $taskRunning && isCurrent;
   $: totalWords = chapters.reduce((sum, c) => sum + (c.content ? c.content.replace(/\s/g, '').length : 0), 0);
 
   $: foreshadows = p?.foreshadows || [];
@@ -275,8 +276,10 @@
               <div class="flex items-center gap-2 flex-wrap">
                 <h2 class="card-title text-base flex-1 min-w-0">{$t('writing.chapter.title', { num: ch.num, title: ch.title })}</h2>
                 <span class="badge badge-sm {statusMeta[ch.status]?.cls || 'badge-ghost'}">{statusMeta[ch.status]?.label || ch.status}</span>
-                {#if wordCount > 0}
-                  <span class="text-xs text-base-content/40">{$t('writing.chapter.words', { n: wordCount.toLocaleString() })}</span>
+                {#if showTaskTokens}
+                  <TaskTokenBadge className="text-xs text-base-content/40 font-mono" />
+                {:else if chapterWordCount > 0}
+                  <span class="text-xs text-base-content/40">{$t('writing.chapter.words', { n: chapterWordCount.toLocaleString() })}</span>
                 {/if}
               </div>
 

--- a/handlers.go
+++ b/handlers.go
@@ -40,6 +40,7 @@ type Handlers struct {
 	activeWork  int
 	taskCtx     context.Context
 	taskCancel  context.CancelFunc
+	taskTokens  *TaskTokenUsage
 	autoConfirm bool // 自动确认模式：章节生成完成后自动确认并继续生成下一章
 
 	pendingContinueContent string
@@ -163,7 +164,10 @@ func (h *Handlers) tryStartTask() bool {
 	}
 	h.taskRunning = true
 	h.activeWork = 1
-	h.taskCtx, h.taskCancel = context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx, h.taskTokens = withTaskTokens(ctx, h.logger)
+	h.taskCtx = ctx
+	h.taskCancel = cancel
 	return true
 }
 
@@ -990,14 +994,22 @@ func (h *Handlers) GetStatus(w http.ResponseWriter, r *http.Request) {
 	if h.cfg != nil {
 		lang = NormalizeLanguage(h.cfg.Language)
 	}
-	h.writeJSON(w, http.StatusOK, map[string]interface{}{
+	resp := map[string]interface{}{
 		"phase":            h.state.Phase,
 		"title":            h.state.Title,
 		"total_chapters":   len(h.state.Chapters),
 		"is_task_running":  h.isTaskRunning(),
 		"auto_confirm":     h.isAutoConfirmOn(),
 		"project_language": lang,
-	})
+	}
+	if h.isTaskRunning() && h.taskTokens != nil {
+		prompt, completion := h.taskTokens.Snapshot()
+		resp["token_usage"] = map[string]int{
+			"prompt_tokens":     prompt,
+			"completion_tokens": completion,
+		}
+	}
+	h.writeJSON(w, http.StatusOK, resp)
 }
 
 func (h *Handlers) GetForeshadows(w http.ResponseWriter, r *http.Request) {

--- a/logger.go
+++ b/logger.go
@@ -97,10 +97,10 @@ func (lb *LogBroadcaster) StreamStart(chapterIdx int) {
 	})
 }
 
-func (lb *LogBroadcaster) StreamProgress(chapterIdx int, charCount int) {
-	lb.Emit("stream_progress", map[string]interface{}{
-		"chapter_idx": chapterIdx,
-		"char_count":  charCount,
+func (lb *LogBroadcaster) TokenUsage(promptTokens, completionTokens int) {
+	lb.Emit("token_usage", map[string]int{
+		"prompt_tokens":     promptTokens,
+		"completion_tokens": completionTokens,
 	})
 }
 

--- a/tokens.go
+++ b/tokens.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+type taskTokenCtxKey struct{}
+
+const tokenEmitInterval = 2 * time.Second
+
+// TaskTokenUsage accumulates prompt/completion tokens for one async task.
+type TaskTokenUsage struct {
+	mu sync.Mutex
+
+	committedPrompt     int
+	committedCompletion int
+	pendingPrompt       int
+	pendingCompletion   int
+
+	logger   *LogBroadcaster
+	lastEmit time.Time
+}
+
+func newTaskTokenUsage(logger *LogBroadcaster) *TaskTokenUsage {
+	return &TaskTokenUsage{logger: logger}
+}
+
+func withTaskTokens(ctx context.Context, logger *LogBroadcaster) (context.Context, *TaskTokenUsage) {
+	usage := newTaskTokenUsage(logger)
+	return context.WithValue(ctx, taskTokenCtxKey{}, usage), usage
+}
+
+func taskTokensFromContext(ctx context.Context) *TaskTokenUsage {
+	if ctx == nil {
+		return nil
+	}
+	usage, _ := ctx.Value(taskTokenCtxKey{}).(*TaskTokenUsage)
+	return usage
+}
+
+func countMessageRunes(messages []Message) int {
+	n := 0
+	for _, m := range messages {
+		n += utf8.RuneCountInString(m.Content)
+	}
+	return n
+}
+
+func (t *TaskTokenUsage) beginCall(messages []Message) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.pendingPrompt = estimateTokensFromRunes(countMessageRunes(messages))
+	t.pendingCompletion = 0
+	t.mu.Unlock()
+	t.maybeEmit(true)
+}
+
+func (t *TaskTokenUsage) updateStreamContent(content string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.pendingCompletion = estimateTokensFromRunes(utf8.RuneCountInString(content))
+	t.mu.Unlock()
+	t.maybeEmit(false)
+}
+
+func (t *TaskTokenUsage) finishCall(promptTokens, completionTokens int, hasUsage bool, messages []Message, output string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	if hasUsage {
+		t.committedPrompt += promptTokens
+		t.committedCompletion += completionTokens
+	} else {
+		t.committedPrompt += estimateTokensFromRunes(countMessageRunes(messages))
+		t.committedCompletion += estimateTokensFromRunes(utf8.RuneCountInString(output))
+	}
+	t.pendingPrompt = 0
+	t.pendingCompletion = 0
+	t.mu.Unlock()
+	t.maybeEmit(true)
+}
+
+func (t *TaskTokenUsage) Snapshot() (prompt, completion int) {
+	if t == nil {
+		return 0, 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.committedPrompt + t.pendingPrompt, t.committedCompletion + t.pendingCompletion
+}
+
+func (t *TaskTokenUsage) maybeEmit(force bool) {
+	if t == nil || t.logger == nil {
+		return
+	}
+	t.mu.Lock()
+	now := time.Now()
+	if !force && !t.lastEmit.IsZero() && now.Sub(t.lastEmit) < tokenEmitInterval {
+		t.mu.Unlock()
+		return
+	}
+	prompt := t.committedPrompt + t.pendingPrompt
+	completion := t.committedCompletion + t.pendingCompletion
+	t.lastEmit = now
+	t.mu.Unlock()
+	t.logger.TokenUsage(prompt, completion)
+}

--- a/writing.go
+++ b/writing.go
@@ -378,15 +378,8 @@ func generateChapterContentStream(ctx context.Context, apiCfg *APIConfig, cfg *C
 		systemPrompt = SystemPromptFor(lang, "author_default")
 	}
 
-	totalChars := 0
-	nextReport := 500
 	onChunk := func(chunk string) {
 		logger.ContentChunk(idx, chunk)
-		totalChars += len([]rune(chunk))
-		if totalChars >= nextReport {
-			logger.StreamProgress(idx, totalChars)
-			nextReport += 500
-		}
 	}
 
 	// 通知前端清空流式缓冲（事实核查重试/自动连写时避免内容叠加）
@@ -541,15 +534,8 @@ func reviseChapterContentStream(ctx context.Context, apiCfg *APIConfig, cfg *Con
 	}
 	systemPrompt += SystemPromptFor(lang, "chapter_revision_suffix")
 
-	totalChars := 0
-	nextReport := 500
 	onChunk := func(chunk string) {
 		logger.ContentChunk(chapterIdx, chunk)
-		totalChars += len([]rune(chunk))
-		if totalChars >= nextReport {
-			logger.StreamProgress(chapterIdx, totalChars)
-			nextReport += 500
-		}
 	}
 
 	logger.StreamStart(chapterIdx)
@@ -794,15 +780,8 @@ func PolishChapterAction(ctx context.Context, apiCfg *APIConfig, cfg *Config, st
 
 	systemPrompt := SystemPromptFor(cfg.Language, "polish_editor")
 
-	totalChars := 0
-	nextReport := 500
 	onChunk := func(chunk string) {
 		logger.ContentChunk(chapterIdx, chunk)
-		totalChars += len([]rune(chunk))
-		if totalChars >= nextReport {
-			logger.StreamProgress(chapterIdx, totalChars)
-			nextReport += 500
-		}
 	}
 
 	logger.StreamStart(chapterIdx)


### PR DESCRIPTION
## Summary
- Track prompt/completion token usage per AI task and surface it in the header, writing page, and chat panel via SSE.
- Improve the project creation UI (full-width name field and language selector).

## Test plan
- [ ] Start any AI task and confirm token counts update in the UI
- [ ] Create a new project with both ZH and EN language options
- [ ] Verify SSE reconnect and task end reset token display


Made with [Cursor](https://cursor.com)