### PR TITLE
fix: delete_chapter targets writing frontier, not outline tail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ task dev                              # 编译并启动 Go 后端
 | `prose_units.go` | `countProseUnits`（CJK +1；连续字母数字 token +1，内部 `.` `,` `-` `#` 连接；全角字母数字视同半角；标点/空白断词不计数；中英文共用） |
 | `writing_length.go` | `calcChapterLengthRange`（±1000 字或 ±15% 取较大者）、`generateChapterContentWithLengthControl`（生成/重写间 `maybeUpdateBestDraft` 保留最佳稿；略超/略低 soft 容忍跳过 adjust；中度偏差对 best 压缩/扩展；adjust 未改善则回退 best；仍超限 `log.chapter_length_off_range` 警告，不阻塞自动确认）、老模板 `finalizeChapterWritingPrompt` 兜底 |
 | `writing.go` | `GenerateChapterAction`（含写前大纲一致性检查，共 6 步；第 2 步经 `generateChapterContentWithLengthControl` 控字数；第 5 步更新伏笔并落盘 `Foreshadows.md`；第 6 步维护叙事记忆）、`ReviseChapterAction`/`ReviseSpecificChapterAction`（修订后同步更新伏笔与记忆）、`ConfirmChapterAction`、`PolishChapterAction`、`SmoothTransitionsAction`（批量优化已确认章节衔接，逐章最小化重写开头、逐章落盘）、`parseFactCheckResult`（JSON 优先 + 字符串 fallback）、`checkOutlineConsistency`（写前检查本章大纲与已写剧情冲突，冲突时最小化修订本章大纲）、章节内容生成/摘要/事实核查/流式输出、`stripChapterMetaProse`（生成/修订/润色后剔除首尾元信息行）、`buildHistorySummary`、`buildPreviousChapterTail`（上一章尾部约 800 字注入写作 prompt）、`buildOutlineConstraints`（全书章节脉络反向约束：后续 10 章大纲防提前出现 + 前文大纲防一次性事件重复，注入写作与事实核查 prompt）、`appendIfMissingPlaceholder`（老项目持久化旧模板缺新占位符时把上下文块追加到渲染结果末尾兜底）、`splitChapterOpening`、`syncMemoryAfterChapter`（第 6 步记忆维护）、`calcMemoryMaxTokens`（记忆 token 上限自动计算） |
+| `writing_delete.go` | `resolveDeleteChapterTarget` / `DeleteFrontierChapter`：`delete_chapter` 清除**写作前沿**章节正文（`CurrentChapterIndex` 处 review 章；或下一章 pending 时前一 accepted 章；或全书已确认时的最后一章），同步回退指针、清除该章叙事记忆；`formatWritingFrontierInfo` 注入 Agent 系统提示 |
 | `foreshadow.go` | `SuggestForeshadows`、`UpdateForeshadows`、伏笔格式化注入、伏笔告警、`BuildForeshadowRoadmapMarkdown`、`SaveForeshadowRoadmap`、`syncForeshadowsAfterChapter`、`NextForeshadowID` |
 | `foreshadow_consistency.go` | `CheckForeshadowOutlineConsistency`、`RunForeshadowOutlineCheckAndSave`（大纲/伏笔变更后自动检查，报告写入 `progress.last_foreshadow_outline_report`） |
 | `writing_conflict.go` | `analyzeWritingConflict`、`WritingConflictError`、事实核查多次失败后的根因分析与用户处理选项 |
@@ -263,7 +264,7 @@ API 配置（`APIConfig`）与故事配置（`Config`）完全分离，分别保
 
 防止 AI 误删用户数据的多层防护：
 
-1. **系统提示词安全规则**：`buildAgentSystemPrompt` 包含最高优先级的「安全规则」（修改 ≠ 删除）和「工具选择指南」，明确指示修改章节细节必须用 `revise_chapter` 而非删除重写；**缩章/整本重生大纲**（尚无已确认章节）须 `update_project_config` + `generate_outline`，禁止 `revise_outline` 缩章、禁止 `delete_chapters_from` 减章、无需先 `delete_outline`
+1. **系统提示词安全规则**：`buildAgentSystemPrompt` 包含最高优先级的「安全规则」（修改 ≠ 删除）和「工具选择指南」，明确指示修改章节细节必须用 `revise_chapter` 而非删除重写；删除写作前沿单章用 `delete_chapter`（**禁止**误用 `delete_chapters_from`）；删更早章节及之后正文才用 `delete_chapters_from` 并须复述范围；**缩章/整本重生大纲**（尚无已确认章节）须 `update_project_config` + `generate_outline`，禁止 `revise_outline` 缩章、禁止 `delete_chapters_from` 减章、无需先 `delete_outline`
 2. **破坏性工具二次确认**：`delete_chapter`、`delete_chapters_from`、`delete_outline`、`reset_progress` 必须传入 `confirm: true` 参数，否则返回警告信息要求 AI 先向用户确认
 3. **`revise_chapter` 支持任意章节**：可选 `num` 参数，当前审核中章节走 `ReviseChapterAction`（完整流程），其他章节（含已确认）走 `ReviseSpecificChapterAction`（最小化定向修订，不影响其他章节和大纲）
 4. **大纲重新生成保护**：`GenerateOutlineAction` 和 `generate_outline` 工具在存在已确认章节时拒绝执行（防止覆盖已完成内容），追加章节需使用「生成后续大纲」；`generate_outline` 会完全替换 pending 大纲，读取 `config.json` 的 `chapter_count` / `target_words_per_chapter`
@@ -458,7 +459,7 @@ pending → writing → review → accepted
 | POST | `/api/postprocess/consistency` | 异步 | 仅重新运行全书一致性核查 |
 | POST | `/api/postprocess/roadmap` | 异步 | 根据已有报告重新生成路线图 |
 | POST | `/api/postprocess/execute` | 异步 | 执行已勾选工单（可选前置衔接优化 + 逐章修订/润色，逐条落盘可随时停止） |
-| DELETE | `/api/chapter` | 同步 | 删除最后章节 |
+| DELETE | `/api/chapter` | 同步 | 删除写作前沿章节正文（`DeleteFrontierChapter`） |
 | DELETE | `/api/chapters/from/{num}` | 同步 | 从第 N 章删除到末尾 |
 | DELETE | `/api/outline` | 同步 | 删除大纲 |
 | POST | `/api/task/stop` | 同步 | 停止当前运行的任务 |

--- a/agent.go
+++ b/agent.go
@@ -272,6 +272,11 @@ func buildAgentSystemPromptZH(ctx *AgentContext, toolDesc string) string {
 		}
 	}
 
+	if frontierInfo := formatWritingFrontierInfo(ctx.State, LangZH); frontierInfo != "" {
+		sb.WriteString("\n")
+		sb.WriteString(frontierInfo)
+	}
+
 	sb.WriteString("\n")
 
 	enabledSkills := GetEnabledSkills(ctx.Skills, ctx.Config.SkillConfig)
@@ -314,6 +319,8 @@ func buildAgentSystemPromptZH(ctx *AgentContext, toolDesc string) string {
 	sb.WriteString("- 修改某章的大纲（未写作的 pending 章节）→ edit_chapter_outline(num, title, outline)\n")
 	sb.WriteString("- 对现有大纲提修改意见且**章数不变** → revise_outline(feedback)（只更新未确认章节的标题/大纲，不能增减章节总数）\n")
 	sb.WriteString("- **调整总章数 / 整本重写大纲**（尚无已确认章节）→ ① update_project_config(chapter_count, target_words_per_chapter) ② generate_outline。generate_outline 会**完全替换**当前全部 pending 大纲；无需先 delete_outline，禁止用 revise_outline 缩章/增章，禁止用 delete_chapters_from\n")
+	sb.WriteString("- 删除写作前沿章节正文（待确认章，或已确认但下一章尚未开始写作）→ delete_chapter。先核对项目信息中的「delete_chapter 当前可删」章号；**禁止**为此使用 delete_chapters_from\n")
+	sb.WriteString("- 删除更早某一章及之后全部正文 → delete_chapters_from(num)（从第 num 章清到全书末章，须先向用户复述范围并确认）。若用户只想删前沿那一章，必须用 delete_chapter\n")
 	sb.WriteString("- 生成下一章正文 → generate_chapter\n")
 	sb.WriteString("- 已有确认章节、想追加新章节 → 不要用 generate_outline（会被拒绝），告知用户在大纲页使用「生成后续大纲」\n\n")
 
@@ -371,6 +378,11 @@ func buildAgentSystemPromptEN(ctx *AgentContext, toolDesc string) string {
 		}
 	}
 
+	if frontierInfo := formatWritingFrontierInfo(ctx.State, LangEN); frontierInfo != "" {
+		sb.WriteString("\n")
+		sb.WriteString(frontierInfo)
+	}
+
 	sb.WriteString("\n")
 
 	enabledSkills := GetEnabledSkills(ctx.Skills, ctx.Config.SkillConfig)
@@ -413,6 +425,8 @@ func buildAgentSystemPromptEN(ctx *AgentContext, toolDesc string) string {
 	sb.WriteString("- Edit a pending chapter's outline -> edit_chapter_outline(num, title, outline)\n")
 	sb.WriteString("- Give feedback on the existing outline while **keeping the same chapter count** -> revise_outline(feedback) (updates title/outline of unconfirmed chapters only; cannot add or remove chapters)\n")
 	sb.WriteString("- **Change total chapter count / regenerate the whole outline** (no confirmed chapters yet) -> ① update_project_config(chapter_count, target_words_per_chapter) ② generate_outline. generate_outline **fully replaces** all pending outlines; no delete_outline first, never use revise_outline to shrink/grow chapter count, never use delete_chapters_from\n")
+	sb.WriteString("- Delete prose at the writing frontier (chapter in review, or last accepted while the next chapter has not started) -> delete_chapter. Check \"delete_chapter can remove\" in project info; **never** use delete_chapters_from for this\n")
+	sb.WriteString("- Delete an earlier chapter and all prose after it -> delete_chapters_from(num) (clears chapter num through the last outline slot; restate the range and get confirmation). If the user only wants the frontier chapter removed, use delete_chapter\n")
 	sb.WriteString("- Generate the next chapter's prose -> generate_chapter\n")
 	sb.WriteString("- Confirmed chapters exist and the user wants to append more -> do NOT use generate_outline (it will be rejected); tell the user to use \"Generate Continuation Outline\" on the Outline page\n\n")
 
@@ -1501,32 +1515,43 @@ func getBuiltinTools() []Tool {
 		},
 		{
 			Name:        "delete_chapter",
-			Description: "【危险·不可逆】清除最后一个章节的正文内容（保留大纲）。仅当用户明确要求删除时使用，且必须先向用户确认。",
+			Description: "【危险·不可逆】清除写作前沿章节的正文（保留大纲）。前沿=CurrentChapterIndex 处 review 章，或下一章 pending 时前一 accepted 章，或全书已确认时的最后一章。仅删这一章；删更早章节须用 delete_chapters_from。须先向用户确认。",
 			Parameters:  `{"confirm": true}`,
 			Execute: func(args json.RawMessage, ctx *AgentContext) (string, error) {
-				if msg := requireConfirm(ctx, args, "清除最后一个章节的正文"); msg != "" {
-					return msg, nil
-				}
 				if len(ctx.State.Chapters) == 0 {
 					return "", agentErr(ctx, "no_chapters_to_delete")
 				}
-				lastIdx := len(ctx.State.Chapters) - 1
-				ch := &ctx.State.Chapters[lastIdx]
-				if ch.Status == StatusWriting {
-					return "", agentErr(ctx, "writing_chapter_cannot_delete")
+				idx, resolveErr := resolveDeleteChapterTarget(ctx.State)
+				if resolveErr != nil {
+					switch resolveErr {
+					case ErrWritingChapterCannotDelete:
+						return "", agentErr(ctx, "writing_chapter_cannot_delete")
+					case ErrDeleteFrontierUnavailable:
+						return "", agentErr(ctx, "delete_frontier_unavailable")
+					default:
+						return "", agentErr(ctx, "no_chapters_to_delete")
+					}
 				}
-				deleteFile(ChapterMarkdownPath(ctx.ProjectDir, ch.Num))
-				ch.Content = ""
-				ch.Summary = ""
-				ch.Status = StatusPending
-				if ctx.State.CurrentChapterIndex > lastIdx {
-					ctx.State.CurrentChapterIndex = lastIdx
+				targetNum := ctx.State.Chapters[idx].Num
+				if msg := requireConfirm(ctx, args, fmt.Sprintf("清除第 %d 章正文（写作前沿）", targetNum)); msg != "" {
+					return msg, nil
+				}
+				num, err := DeleteFrontierChapter(ctx.State, ctx.ProjectDir)
+				if err != nil {
+					switch err {
+					case ErrWritingChapterCannotDelete:
+						return "", agentErr(ctx, "writing_chapter_cannot_delete")
+					case ErrDeleteFrontierUnavailable:
+						return "", agentErr(ctx, "delete_frontier_unavailable")
+					default:
+						return "", agentErr(ctx, "no_chapters_to_delete")
+					}
 				}
 				if err := SaveProgress(ctx.ProgressPath, ctx.State); err != nil {
 					return "", agentErr(ctx, "save_progress_failed", err)
 				}
-				ctx.Logger.SuccessKey("log.chapter_deleted", ch.Num)
-				return agentMsg(ctx, "agent.chapter_deleted", ch.Num), nil
+				ctx.Logger.SuccessKey("log.chapter_deleted", num)
+				return agentMsg(ctx, "agent.chapter_deleted", num), nil
 			},
 		},
 		{

--- a/frontend/src/lib/i18n/index.js
+++ b/frontend/src/lib/i18n/index.js
@@ -120,6 +120,7 @@ const serverMessageEN = {
   '不能删除当前正在使用的项目': 'Cannot delete the currently active project',
   '项目不存在': 'Project not found',
   '没有可删除的章节': 'No chapters to delete',
+  '当前写作前沿没有可删除的章节正文': 'No chapter content at the writing frontier to delete',
   '正在写作中的章节无法删除': 'Cannot delete a chapter that is being written',
   '删除范围内有正在写作中的章节，无法删除': 'Delete range contains a chapter being written; cannot delete',
   '请先生成大纲': 'Generate an outline first',

--- a/handlers.go
+++ b/handlers.go
@@ -1045,26 +1045,19 @@ func (h *Handlers) DeleteChapter(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(h.state.Chapters) == 0 {
-		h.writeErrorReq(w, r, http.StatusBadRequest, "no_chapters_to_delete")
+	num, err := DeleteFrontierChapter(h.state, h.projectDir())
+	if err != nil {
+		switch err {
+		case ErrNoChaptersToDelete:
+			h.writeErrorReq(w, r, http.StatusBadRequest, "no_chapters_to_delete")
+		case ErrWritingChapterCannotDelete:
+			h.writeErrorReq(w, r, http.StatusConflict, "writing_chapter_cannot_delete")
+		case ErrDeleteFrontierUnavailable:
+			h.writeErrorReq(w, r, http.StatusConflict, "delete_frontier_unavailable")
+		default:
+			h.writeErrorReq(w, r, http.StatusInternalServerError, "save_progress_failed", err.Error())
+		}
 		return
-	}
-
-	lastIdx := len(h.state.Chapters) - 1
-	ch := &h.state.Chapters[lastIdx]
-
-	if ch.Status == StatusWriting {
-		h.writeErrorReq(w, r, http.StatusConflict, "writing_chapter_cannot_delete")
-		return
-	}
-
-	deleteFile(ChapterMarkdownPath(h.projectDir(), ch.Num))
-	ch.Content = ""
-	ch.Summary = ""
-	ch.Status = StatusPending
-
-	if h.state.CurrentChapterIndex > lastIdx {
-		h.state.CurrentChapterIndex = lastIdx
 	}
 
 	if err := SaveProgress(h.progressPath, h.state); err != nil {
@@ -1072,7 +1065,7 @@ func (h *Handlers) DeleteChapter(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.logger.SuccessKey("log.chapter_deleted", ch.Num)
+	h.logger.SuccessKey("log.chapter_deleted", num)
 	h.writeJSON(w, http.StatusOK, h.state)
 }
 

--- a/locale.go
+++ b/locale.go
@@ -176,6 +176,10 @@ var errorCatalog = map[string]map[string]string{
 		LangZH: "正在写作中的章节无法删除",
 		LangEN: "Cannot delete a chapter that is being written",
 	},
+	"delete_frontier_unavailable": {
+		LangZH: "当前写作前沿没有可删除的章节正文",
+		LangEN: "No chapter content at the writing frontier to delete",
+	},
 	"writing_range_has_writing": {
 		LangZH: "删除范围内有正在写作中的章节，无法删除",
 		LangEN: "Delete range contains a chapter being written; cannot delete",

--- a/writing_delete.go
+++ b/writing_delete.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrNoChaptersToDelete         = errors.New("no chapters to delete")
+	ErrWritingChapterCannotDelete = errors.New("writing chapter cannot delete")
+	ErrDeleteFrontierUnavailable  = errors.New("delete frontier unavailable")
+)
+
+// resolveDeleteChapterTarget returns the chapter index eligible for delete_chapter:
+// the writing-frontier chapter — review/writing at CurrentChapterIndex, or the last
+// accepted chapter when the next slot is still pending, or the final chapter when
+// the book is fully confirmed.
+func resolveDeleteChapterTarget(state *Progress) (int, error) {
+	if len(state.Chapters) == 0 {
+		return -1, ErrNoChaptersToDelete
+	}
+
+	frontier := state.CurrentChapterIndex
+	if frontier >= len(state.Chapters) {
+		last := len(state.Chapters) - 1
+		if state.Chapters[last].Status == StatusWriting {
+			return -1, ErrWritingChapterCannotDelete
+		}
+		if chapterHasDeletableContent(&state.Chapters[last]) {
+			return last, nil
+		}
+		return -1, ErrDeleteFrontierUnavailable
+	}
+
+	cur := &state.Chapters[frontier]
+	switch cur.Status {
+	case StatusWriting:
+		return -1, ErrWritingChapterCannotDelete
+	case StatusReview:
+		return frontier, nil
+	case StatusPending:
+		if frontier == 0 {
+			return -1, ErrDeleteFrontierUnavailable
+		}
+		prev := &state.Chapters[frontier-1]
+		if prev.Status == StatusAccepted && chapterHasDeletableContent(prev) {
+			return frontier - 1, nil
+		}
+		return -1, ErrDeleteFrontierUnavailable
+	default:
+		return -1, ErrDeleteFrontierUnavailable
+	}
+}
+
+func chapterHasDeletableContent(ch *ChapterState) bool {
+	switch ch.Status {
+	case StatusAccepted, StatusReview:
+		return true
+	default:
+		return ch.Content != "" || ch.Summary != ""
+	}
+}
+
+func purgeMemoryForChapter(state *Progress, chapterNum int) {
+	filtered := state.MemoryEntries[:0]
+	for _, m := range state.MemoryEntries {
+		if m.Chapter != chapterNum {
+			filtered = append(filtered, m)
+		}
+	}
+	state.MemoryEntries = filtered
+}
+
+func clearChapterContentAt(state *Progress, projectDir string, idx int) {
+	ch := &state.Chapters[idx]
+	deleteFile(ChapterMarkdownPath(projectDir, ch.Num))
+	ch.Content = ""
+	ch.Summary = ""
+	ch.Status = StatusPending
+	purgeMemoryForChapter(state, ch.Num)
+}
+
+func adjustCurrentChapterIndexAfterDelete(state *Progress, deletedIdx int) {
+	if deletedIdx < state.CurrentChapterIndex {
+		state.CurrentChapterIndex = deletedIdx
+	} else if state.CurrentChapterIndex >= len(state.Chapters) {
+		state.CurrentChapterIndex = deletedIdx
+	}
+}
+
+// DeleteFrontierChapter clears prose at the writing frontier (see resolveDeleteChapterTarget).
+func DeleteFrontierChapter(state *Progress, projectDir string) (int, error) {
+	idx, err := resolveDeleteChapterTarget(state)
+	if err != nil {
+		return 0, err
+	}
+	num := state.Chapters[idx].Num
+	clearChapterContentAt(state, projectDir, idx)
+	adjustCurrentChapterIndexAfterDelete(state, idx)
+	return num, nil
+}
+
+func formatWritingFrontierInfo(state *Progress, lang string) string {
+	if state.Phase != "writing" || len(state.Chapters) == 0 {
+		return ""
+	}
+
+	zh := NormalizeLanguage(lang) == LangZH
+	var sb strings.Builder
+	if frontier := state.CurrentChapterIndex; frontier < len(state.Chapters) {
+		ch := state.Chapters[frontier]
+		if zh {
+			sb.WriteString(fmt.Sprintf("写作指针: 第 %d 章 [%s]\n", ch.Num, ch.Status))
+		} else {
+			sb.WriteString(fmt.Sprintf("Writing pointer: chapter %d [%s]\n", ch.Num, ch.Status))
+		}
+	} else if zh {
+		sb.WriteString("写作指针: 全书章节已确认完毕\n")
+	} else {
+		sb.WriteString("Writing pointer: all chapters confirmed\n")
+	}
+
+	if idx, err := resolveDeleteChapterTarget(state); err == nil {
+		num := state.Chapters[idx].Num
+		if zh {
+			sb.WriteString(fmt.Sprintf("delete_chapter 当前可删: 第 %d 章（写作前沿）\n", num))
+		} else {
+			sb.WriteString(fmt.Sprintf("delete_chapter can remove: chapter %d (writing frontier)\n", num))
+		}
+	} else if zh {
+		sb.WriteString("delete_chapter 当前不可用（如无正文可删或正在写作中）\n")
+	} else {
+		sb.WriteString("delete_chapter unavailable (nothing to delete or a chapter is writing)\n")
+	}
+	return sb.String()
+}

--- a/writing_delete_test.go
+++ b/writing_delete_test.go
@@ -1,0 +1,150 @@
+package main
+
+import "testing"
+
+func TestResolveDeleteChapterTarget(t *testing.T) {
+	ch := func(num int, status, content string) ChapterState {
+		return ChapterState{Num: num, Status: status, Content: content}
+	}
+
+	tests := []struct {
+		name    string
+		state   Progress
+		wantIdx int
+		wantErr error
+	}{
+		{
+			name:    "empty",
+			state:   Progress{},
+			wantErr: ErrNoChaptersToDelete,
+		},
+		{
+			name: "review at frontier",
+			state: Progress{
+				Phase:               "writing",
+				CurrentChapterIndex: 2,
+				Chapters: []ChapterState{
+					ch(1, StatusAccepted, "a"),
+					ch(2, StatusAccepted, "b"),
+					ch(3, StatusReview, "c"),
+					ch(4, StatusPending, ""),
+				},
+			},
+			wantIdx: 2,
+		},
+		{
+			name: "accepted frontier when next pending",
+			state: Progress{
+				Phase:               "writing",
+				CurrentChapterIndex: 3,
+				Chapters: []ChapterState{
+					ch(1, StatusAccepted, "a"),
+					ch(2, StatusAccepted, "b"),
+					ch(3, StatusAccepted, "c"),
+					ch(4, StatusPending, ""),
+				},
+			},
+			wantIdx: 2,
+		},
+		{
+			name: "book complete deletes last",
+			state: Progress{
+				Phase:               "writing",
+				CurrentChapterIndex: 3,
+				Chapters: []ChapterState{
+					ch(1, StatusAccepted, "a"),
+					ch(2, StatusAccepted, "b"),
+					ch(3, StatusAccepted, "c"),
+				},
+			},
+			wantIdx: 2,
+		},
+		{
+			name: "writing blocks delete",
+			state: Progress{
+				Phase:               "writing",
+				CurrentChapterIndex: 2,
+				Chapters: []ChapterState{
+					ch(1, StatusAccepted, "a"),
+					ch(2, StatusAccepted, "b"),
+					ch(3, StatusWriting, "c"),
+				},
+			},
+			wantErr: ErrWritingChapterCannotDelete,
+		},
+		{
+			name: "nothing written yet",
+			state: Progress{
+				Phase:               "writing",
+				CurrentChapterIndex: 0,
+				Chapters: []ChapterState{
+					ch(1, StatusPending, ""),
+					ch(2, StatusPending, ""),
+				},
+			},
+			wantErr: ErrDeleteFrontierUnavailable,
+		},
+		{
+			name: "review at frontier not earlier accepted",
+			state: Progress{
+				Phase:               "writing",
+				CurrentChapterIndex: 2,
+				Chapters: []ChapterState{
+					ch(1, StatusAccepted, "a"),
+					ch(2, StatusAccepted, "b"),
+					ch(3, StatusReview, "c"),
+				},
+			},
+			wantIdx: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, err := resolveDeleteChapterTarget(&tt.state)
+			if tt.wantErr != nil {
+				if err != tt.wantErr {
+					t.Fatalf("err = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if idx != tt.wantIdx {
+				t.Fatalf("idx = %d, want %d", idx, tt.wantIdx)
+			}
+		})
+	}
+}
+
+func TestDeleteFrontierChapterAdjustsPointer(t *testing.T) {
+	state := &Progress{
+		Phase:               "writing",
+		CurrentChapterIndex: 3,
+		Chapters: []ChapterState{
+			{Num: 1, Status: StatusAccepted, Content: "a"},
+			{Num: 2, Status: StatusAccepted, Content: "b"},
+			{Num: 3, Status: StatusAccepted, Content: "c", Summary: "s"},
+			{Num: 4, Status: StatusPending},
+		},
+		MemoryEntries: []MemoryEntry{{ID: 1, Chapter: 3, Content: "detail"}},
+	}
+
+	num, err := DeleteFrontierChapter(state, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if num != 3 {
+		t.Fatalf("deleted num = %d, want 3", num)
+	}
+	if state.CurrentChapterIndex != 2 {
+		t.Fatalf("pointer = %d, want 2", state.CurrentChapterIndex)
+	}
+	if state.Chapters[2].Status != StatusPending || state.Chapters[2].Content != "" {
+		t.Fatalf("chapter 3 not cleared: %+v", state.Chapters[2])
+	}
+	if len(state.MemoryEntries) != 0 {
+		t.Fatalf("memory not purged: %+v", state.MemoryEntries)
+	}
+}


### PR DESCRIPTION
## Summary
- delete_chapter 删除写作前沿章节而非大纲尾部

## Test plan
- [x] go build 通过
- [ ] 相关功能冒烟验证

Made with [Cursor](https://cursor.com)