### PR TITLE
feat: change default to 12 chapters × 5000 words per chapter

### DIFF
--- a/config.go
+++ b/config.go
@@ -86,8 +86,8 @@ func DefaultConfigForLang(lang string) *Config {
 	cfg := &Config{
 		Language: lang,
 		Story: StoryConfig{
-			ChapterCount:          30,
-			TargetWordsPerChapter: 2500,
+		ChapterCount:          12,
+		TargetWordsPerChapter: 5000,
 		},
 		SkillConfig: &SkillConfig{
 			EnabledSkills: make(map[string]bool),
@@ -157,10 +157,10 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	if cfg.Story.ChapterCount <= 0 {
-		cfg.Story.ChapterCount = 30
+		cfg.Story.ChapterCount = 12
 	}
 	if cfg.Story.TargetWordsPerChapter <= 0 {
-		cfg.Story.TargetWordsPerChapter = 2500
+		cfg.Story.TargetWordsPerChapter = 5000
 	}
 
 	cfg.Language = NormalizeLanguage(cfg.Language)


### PR DESCRIPTION
## Summary
- Update new-project defaults from 30×2500 to 12×5000 words per chapter
- Apply the same fallback values when loading configs with empty chapter count or per-chapter word target

## Test plan
- [x] `go build` passes
- [ ] Create a new project and confirm default chapter count is 12 and target words per chapter is 5000

Made with [Cursor](https://cursor.com)