### PR TITLE
feat: add strict API URL mode with resolved endpoint preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,10 @@ task dev                              # 编译并启动 Go 后端
 | 文件 | 职责 |
 |------|------|
 | `main.go` | 入口，确定程序目录（`progDir`），创建 `storys/` 目录，加载 API 配置，启动 Web 服务器（无项目选择状态）；`var version = "dev"` 通过 CI `-ldflags` 注入实际版本号 |
-| `config.go` | `APIConfig`（含 `ContextBudgetTokens` 全书优化上下文预算）、`Config`（含 `SkillConfig` + `Language`）、`StoryConfig`、`PromptsConfig` 结构体，Load/Save 函数，`DefaultConfigForLang(lang)`、`NormalizeLanguage`、`applyDefaults(lang)` 按语言选择默认 prompts |
+| `config.go` | `APIConfig`（含 `URLStrict` 严格 URL 模式、`ContextBudgetTokens` 全书优化上下文预算）、`Config`（含 `SkillConfig` + `Language`）、`StoryConfig`、`PromptsConfig` 结构体，Load/Save 函数，`DefaultConfigForLang(lang)`、`NormalizeLanguage`、`applyDefaults(lang)` 按语言选择默认 prompts |
 | `state.go` | `Progress`、`ChapterState`、`Foreshadow`、`MemoryEntry` 结构体，`LoadProgress`、`SaveProgress`（原子写入）、`ChapterMarkdownPath`、`SaveChapterMarkdown(projectDir, ...)`、`ForeshadowRoadmapPath`（项目目录 `Foreshadows.md`） |
-| `api.go` | `CallAPI`/`CallAPIMessages`（**内部优先流式缓冲**，失败时回退 `callAPIMessagesSync`）、`CallAPIStream`/`CallAPIStreamMessages`（流式，含 `stream_options.include_usage`）、`CallAPIWithRetry`/`CallAPIWithRetryLog`（无限重试）、`CallAPIStreamWithRetry`/`CallAPIStreamWithRetryLog`，`validateAPIConfig`、`isFatalAPIError`（401/403/404 致命，网络超时可重试）；所有调用经 `taskCtx` 时自动累计 token（优先 API `usage`，否则 rune 估算） |
+| `api.go` | `resolveChatCompletionsURL`/`normalizeURL`（`url_strict` 时仅补 `/chat/completions`；否则路径含 `/vN` 只补 `/chat/completions`，裸域名补 `/v1/chat/completions`）、`CallAPI`/`CallAPIMessages`（**内部优先流式缓冲**，失败时回退 `callAPIMessagesSync`）、`CallAPIStream`/`CallAPIStreamMessages`（流式，含 `stream_options.include_usage`）、`CallAPIWithRetry`/`CallAPIWithRetryLog`（无限重试）、`CallAPIStreamWithRetry`/`CallAPIStreamWithRetryLog`，`validateAPIConfig`、`isFatalAPIError`（401/403/404 致命，网络超时可重试）；所有调用经 `taskCtx` 时自动累计 token（优先 API `usage`，否则 rune 估算） |
+| `api_url_test.go` | `resolveChatCompletionsURL` 表驱动测试（z.ai v4、strict、DeepSeek、完整 URL） |
 | `outline.go` | `generateOutline`（注入 settings 角色列表 + 按 `target_words_per_chapter` 计算大纲字数下限，不足时自动重试）、`reviseOutline`、`GenerateOutlineAction`（存在已确认章节时拒绝整体重新生成；完成后 `runOutlinePostProcessChecks`）、`ReviseOutlineAction`、`ConfirmOutlineAction`、`EditChapterOutline`、`cleanJSONResponse` |
 | `outline_helpers.go` | `calcOutlineLengthRange`、`formatCharacterListForOutline`、`validateOutlineChapterLengths`、`buildOutlineDerivedCharacterContext`（写作时注入未登记大纲人物 stub） |
 | `outline_character.go` | `CheckOutlineCharacterConsistency`、`RunOutlineCharacterCheckAndSave`、`runOutlinePostProcessChecks`（伏笔-大纲 + 大纲人物双检查） |
@@ -123,6 +124,7 @@ task dev                              # 编译并启动 Go 后端
 | `src/main.js` | Svelte 应用挂载点 |
 | `src/app.css` | 全局样式：Tailwind 指令 + 自定义滚动条/toast 动画 |
 | `src/App.svelte` | 根组件：Header（项目badge + 项目语言 badge ZH/EN + 版本号badge + 新版本更新提示（非dev版本检查GitHub releases）+ 「切换 / 新建项目」按钮（任务运行时禁用）+ 阶段badge + 章节进度badge + AI思考中badge + 右侧 UI 语言切换按钮中 / EN） + 左侧竖排导航（配置/大纲/写作/伏笔/记忆/图谱/技能，图标+文字，约 176px）+ 中间页面内容 + 右侧 ChatPanel + Toast 容器；初始加载若有当前项目则 `setLocale(project.language)` |
+| `src/lib/apiUrl.js` | `resolveChatCompletionsURL`：与后端 `api.go` 同逻辑的 URL 预览（配置页展示实际请求地址） |
 | `src/lib/api.js` | `api(method, url, body)` — fetch 封装，自动带 `X-UI-Locale`/`Accept-Language` 头，错误消息走 `translateServerMessage` |
 | `src/lib/router.js` | `currentPage` store + hash 路由监听 |
 | `src/lib/stores.js` | 全局 Svelte stores（progress、config、settings、postprocess、taskRunning、taskTokenUsage、autoConfirm、lastFailedTask、`projectLanguage`、`pendingConfigChanges`/`showConfigChangePanel` 等）+ toast/log 管理 |
@@ -132,7 +134,7 @@ task dev                              # 编译并启动 Go 后端
 | `src/lib/i18n/index.js` | `uiLocale`、`t`/`translate`（`{name}`）、`formatKeyedMessage`/`formatLogEntry`/`formatToolResult`（服务端 key + `{0}`）、`translateServerMessage` legacy 兜底 |
 | `src/lib/i18n/zh.js`, `en.js` | 扁平 key 字典；新增可见文案必须同时在两个文件加 key |
 | `src/pages/Projects.svelte` | 项目选择页：新建项目（名称全宽 + 中文/EN 分段按钮选语言，POST 时携带 `language`）+ 项目列表（每项显示语言 badge，可选择/删除）；选中项目后 `setLocale(project.language)` |
-| `src/pages/Config.svelte` | 配置页：API 配置（含上下文预算 tokens）、故事配置（直接 PUT 保存 + 关键设定变更时提示协调）、写作风格与叙述视角、AI 配置变更确认面板（`ConfigChangePanel`）、角色管理、世界观管理、组织管理（卡片 + 成员勾选）、关系管理（卡片 + 源/目标实体选择）；任务运行时所有输入控件禁用 |
+| `src/pages/Config.svelte` | 配置页：API 配置（含 `url_strict` 严格 URL 模式、解析后 endpoint 预览、上下文预算 tokens）、故事配置（直接 PUT 保存 + 关键设定变更时提示协调）、写作风格与叙述视角、AI 配置变更确认面板（`ConfigChangePanel`）、角色管理、世界观管理、组织管理（卡片 + 成员勾选）、关系管理（卡片 + 源/目标实体选择）；任务运行时所有输入控件禁用 |
 | `src/pages/Outline.svelte` | 大纲页：直接操作按钮（生成/确认/修订意见/删除/生成后续大纲）+ 导入续写 + pending 章节内联编辑 + 流式预览 + 标题/梗概展示优先 config（`preferUserValue` 一致）+ `ConfigChangePanel` + 未登记大纲人物确认面板（SSE `outline_character_suggestions`） |
 | `src/components/ConfigChangePanel.svelte` | AI 配置变更确认面板：展示 pending 提案（当前 vs 建议）、勾选采纳 / 全部忽略；SSE `config_change_proposal` 触发 |
 | `src/pages/Writing.svelte` | 写作页：章节列表（状态点）+ 直接操作（生成/确认/修改意见/去AI味，自动区分当前章修订与定向修订）+ 事实核查冲突处理面板（`pending_writing_conflict`，可选修改大纲/伏笔/重试/保留稿进入审核）+ 自动确认模式开关（toggle，随时可开关）+ 伏笔追踪摘要卡片（活跃/超期/临近回收）+ 优化章节衔接（进度卡片工具栏小按钮，已确认 ≥ 2 章时显示）+ 导出 TXT + 复制 + 上下章导航 + 流式尾部窗口展示（含「仅显示最新内容」提示；任务进行中当前章显示 taskTokenUsage，空闲时以 `countProseUnits` 显示正文字数）+ rAF 自动滚动（自动确认模式下自动跟随正在生成的章节）+ 全书完成后展示 `PostProcessPanel` |

--- a/README.en.md
+++ b/README.en.md
@@ -55,7 +55,7 @@ Then open `http://localhost:48090` (the port can be overridden via the `PORT` en
 
 On first launch you will be asked to create a project. Once a project is open, the "Config" page asks for:
 
-- **API base URL**: any OpenAI-compatible endpoint, e.g. `https://api.deepseek.com`, `http://localhost:11434/v1` (the trailing `/v1` is optional)
+- **API base URL**: OpenAI-compatible base URL (the app appends `/chat/completions`), e.g. `https://api.deepseek.com`, `https://api.openai.com/v1`, `https://api.z.ai/api/paas/v4`; a bare hostname gets `/v1` added automatically. For non-standard paths (e.g. z.ai Coding Plan), enable **Strict URL mode**
 - **Model name**: e.g. `deepseek-chat`, `gpt-4o`
 - **API key**: leave empty for local models
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 
 首次进入会提示创建项目。创建后在「配置」页填写：
 
-- **API 地址**：任意 OpenAI 兼容接口，如 `https://api.deepseek.com`、`http://localhost:11434/v1`（带不带 `/v1` 均可）
+- **API 地址**：任意 OpenAI 兼容接口的 Base URL（程序会自动补 `/chat/completions`），如 `https://api.deepseek.com`、`https://api.openai.com/v1`、`https://api.z.ai/api/paas/v4`；仅填域名时会自动补 `/v1`。非标准路径（如 z.ai Coding Plan）可开启「严格 URL 模式」
 - **模型名称**：如 `deepseek-chat`、`gpt-4o` 等
 - **API Key**：本地模型可留空
 

--- a/api.go
+++ b/api.go
@@ -42,17 +42,45 @@ type ChatResponse struct {
 	Usage *tokenUsage `json:"usage,omitempty"`
 }
 
-func normalizeURL(base string) string {
-	base = strings.TrimSpace(base)
-	base = strings.TrimSuffix(base, "/")
-
-	if !strings.HasSuffix(base, "/v1") && !strings.Contains(base, "/v1/") {
-		if !strings.Contains(base, "11434") {
-			base = base + "/v1"
+func hasAPIVersionSegment(u string) bool {
+	for _, seg := range strings.Split(u, "/") {
+		if len(seg) >= 2 && seg[0] == 'v' && seg[1] >= '0' && seg[1] <= '9' {
+			return true
 		}
 	}
+	return false
+}
 
-	return base + "/chat/completions"
+// resolveChatCompletionsURL builds the POST endpoint from base_url and url_strict.
+// Must stay in sync with frontend/src/lib/apiUrl.js.
+func resolveChatCompletionsURL(base string, strict bool) string {
+	base = strings.TrimSpace(base)
+	base = strings.TrimSuffix(base, "/")
+	if base == "" {
+		return ""
+	}
+	if strings.HasSuffix(base, "/chat/completions") {
+		return base
+	}
+	if strict {
+		return base + "/chat/completions"
+	}
+	if hasAPIVersionSegment(base) {
+		return base + "/chat/completions"
+	}
+	return base + "/v1/chat/completions"
+}
+
+func resolveAPIBase(base string, strict bool) string {
+	u := resolveChatCompletionsURL(base, strict)
+	return strings.TrimSuffix(u, "/chat/completions")
+}
+
+func normalizeURL(apiCfg *APIConfig) string {
+	if apiCfg == nil {
+		return ""
+	}
+	return resolveChatCompletionsURL(apiCfg.BaseURL, apiCfg.URLStrict)
 }
 
 // FetchModelContextWindow 从 API 的 /models 端点获取指定模型的上下文窗口大小。
@@ -61,14 +89,7 @@ func FetchModelContextWindow(apiCfg *APIConfig) int {
 	if apiCfg == nil || strings.TrimSpace(apiCfg.BaseURL) == "" || strings.TrimSpace(apiCfg.Model) == "" {
 		return 0
 	}
-	base := strings.TrimSpace(apiCfg.BaseURL)
-	base = strings.TrimSuffix(base, "/")
-	if !strings.HasSuffix(base, "/v1") && !strings.Contains(base, "/v1/") {
-		if !strings.Contains(base, "11434") {
-			base = base + "/v1"
-		}
-	}
-	modelsURL := base + "/models/" + apiCfg.Model
+	modelsURL := resolveAPIBase(apiCfg.BaseURL, apiCfg.URLStrict) + "/models/" + apiCfg.Model
 
 	req, err := http.NewRequest("GET", modelsURL, nil)
 	if err != nil {
@@ -165,7 +186,7 @@ func CallAPIMessages(ctx context.Context, apiCfg *APIConfig, messages []Message)
 
 // callAPIMessagesSync 同步 HTTP 调用（仅作流式失败时的回退）。
 func callAPIMessagesSync(ctx context.Context, apiCfg *APIConfig, messages []Message) (string, error) {
-	fullURL := normalizeURL(apiCfg.BaseURL)
+	fullURL := normalizeURL(apiCfg)
 	tracker := taskTokensFromContext(ctx)
 	tracker.beginCall(messages)
 
@@ -303,7 +324,7 @@ func CallAPIStream(ctx context.Context, apiCfg *APIConfig, system, user string, 
 
 // CallAPIStreamMessages 以完整的多轮消息数组调用 API（流式）。
 func CallAPIStreamMessages(ctx context.Context, apiCfg *APIConfig, messages []Message, onChunk func(string)) (string, error) {
-	fullURL := normalizeURL(apiCfg.BaseURL)
+	fullURL := normalizeURL(apiCfg)
 	tracker := taskTokensFromContext(ctx)
 	tracker.beginCall(messages)
 

--- a/api_url_test.go
+++ b/api_url_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+func TestResolveChatCompletionsURL(t *testing.T) {
+	tests := []struct {
+		base   string
+		strict bool
+		want   string
+	}{
+		{"https://api.z.ai/api/paas/v4", false, "https://api.z.ai/api/paas/v4/chat/completions"},
+		{"https://api.z.ai/api/coding/paas/v4", true, "https://api.z.ai/api/coding/paas/v4/chat/completions"},
+		{"https://api.deepseek.com", false, "https://api.deepseek.com/v1/chat/completions"},
+		{"https://api.deepseek.com", true, "https://api.deepseek.com/chat/completions"},
+		{"https://api.openai.com/v1", false, "https://api.openai.com/v1/chat/completions"},
+		{"https://api.z.ai/api/paas/v4/chat/completions", false, "https://api.z.ai/api/paas/v4/chat/completions"},
+		{"  https://api.example.com/v1/  ", false, "https://api.example.com/v1/chat/completions"},
+		{"", false, ""},
+	}
+	for _, tc := range tests {
+		got := resolveChatCompletionsURL(tc.base, tc.strict)
+		if got != tc.want {
+			t.Errorf("resolveChatCompletionsURL(%q, %v) = %q, want %q", tc.base, tc.strict, got, tc.want)
+		}
+	}
+}

--- a/config.go
+++ b/config.go
@@ -9,6 +9,7 @@ import (
 type APIConfig struct {
 	APIKey               string `json:"api_key"`
 	BaseURL              string `json:"base_url"`
+	URLStrict            bool   `json:"url_strict,omitempty"` // true = 不自动插入 /v1，仅补 /chat/completions
 	Model                string `json:"model"`
 	MaxTokens            int    `json:"max_tokens,omitempty"`           // 0 = 模型默认；Agent 调用建议 ≥ 8192
 	HTTPTimeoutSeconds   int    `json:"http_timeout_seconds"`

--- a/frontend/src/lib/apiUrl.js
+++ b/frontend/src/lib/apiUrl.js
@@ -1,0 +1,20 @@
+// Must stay in sync with resolveChatCompletionsURL in api.go.
+
+function hasAPIVersionSegment(u) {
+  for (const seg of u.split('/')) {
+    if (seg.length >= 2 && seg[0] === 'v' && seg[1] >= '0' && seg[1] <= '9') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** @returns {string} resolved chat/completions URL, or '' if base is empty */
+export function resolveChatCompletionsURL(base, strict) {
+  let b = (base || '').trim().replace(/\/+$/, '');
+  if (!b) return '';
+  if (b.endsWith('/chat/completions')) return b;
+  if (strict) return b + '/chat/completions';
+  if (hasAPIVersionSegment(b)) return b + '/chat/completions';
+  return b + '/v1/chat/completions';
+}

--- a/frontend/src/lib/i18n/en.js
+++ b/frontend/src/lib/i18n/en.js
@@ -279,6 +279,9 @@ export default {
   // ---- Config page ----
   'config.api.title': 'API config',
   'config.api.baseUrl': 'API base URL',
+  'config.api.urlStrict': 'Strict URL mode',
+  'config.api.urlStrictHint': 'When enabled, /v1 is not added; only /chat/completions is appended.',
+  'config.api.resolvedUrl': 'Resolved endpoint',
   'config.api.model': 'Model',
   'config.api.timeout': 'HTTP timeout (s)',
   'config.api.maxTokens': 'Max output tokens',

--- a/frontend/src/lib/i18n/zh.js
+++ b/frontend/src/lib/i18n/zh.js
@@ -283,6 +283,9 @@ export default {
   // ---- Config page ----
   'config.api.title': 'API 配置',
   'config.api.baseUrl': 'API Base URL',
+  'config.api.urlStrict': '严格 URL 模式',
+  'config.api.urlStrictHint': '开启后不会自动插入 /v1，仅在末尾补 /chat/completions。',
+  'config.api.resolvedUrl': '实际请求地址',
   'config.api.model': 'Model',
   'config.api.timeout': 'HTTP 超时（秒）',
   'config.api.maxTokens': '最大输出 Tokens',

--- a/frontend/src/pages/Config.svelte
+++ b/frontend/src/pages/Config.svelte
@@ -3,6 +3,7 @@
   import { api } from '../lib/api.js';
   import { apiConfig, config, progress, settings, editingCharID, editingWvID, wvFilter, addToast, showConfirm, taskRunning } from '../lib/stores.js';
   import { t } from '../lib/i18n/index.js';
+  import { resolveChatCompletionsURL } from '../lib/apiUrl.js';
   import ConfigChangePanel from '../components/ConfigChangePanel.svelte';
 
   export let sendToChat = async () => {};
@@ -35,9 +36,11 @@
   $: cfgKey = $apiConfig?.api_key || '';
   $: cfgTimeout = $apiConfig?.http_timeout_seconds || 300;
 
-  let localApiCfg = { base_url: '', model: '', api_key: '', http_timeout_seconds: 300, max_tokens: 0, context_budget_tokens: 900000 };
+  let localApiCfg = { base_url: '', url_strict: false, model: '', api_key: '', http_timeout_seconds: 300, max_tokens: 0, context_budget_tokens: 900000 };
   let localStoryCfg = { type: '', title: '', chapter_count: 30, target_words_per_chapter: 2500, writing_style: '', writing_pov: '', story_synopsis: '' };
   let testingApi = false;
+
+  $: resolvedChatURL = resolveChatCompletionsURL(localApiCfg.base_url, !!localApiCfg.url_strict);
 
   let apiCfgSnapshot = '';
   let storyCfgSnapshot = '';
@@ -45,7 +48,11 @@
   $: if ($apiConfig) {
     const snap = JSON.stringify($apiConfig);
     if (snap !== apiCfgSnapshot) {
-      localApiCfg = { ...$apiConfig };
+      localApiCfg = {
+        base_url: '', url_strict: false, model: '', api_key: '', http_timeout_seconds: 300, max_tokens: 0, context_budget_tokens: 900000,
+        ...$apiConfig,
+        url_strict: !!$apiConfig.url_strict,
+      };
       apiCfgSnapshot = snap;
     }
   }
@@ -371,7 +378,17 @@
         <div class="grid grid-cols-2 gap-x-3 gap-y-1.5">
           <div class="col-span-2">
             <span class="text-xs text-base-content/50 mb-0.5 block">{$t('config.api.baseUrl')}</span>
-            <input type="text" class="input input-sm w-full" bind:value={localApiCfg.base_url} placeholder="https://api.example.com/v1/" disabled={$taskRunning || testingApi} />
+            <input type="text" class="input input-sm w-full" bind:value={localApiCfg.base_url} placeholder="https://api.openai.com/v1" disabled={$taskRunning || testingApi} />
+            <label class="label cursor-pointer justify-start gap-2 py-1 px-0 min-h-0">
+              <input type="checkbox" class="toggle toggle-xs" bind:checked={localApiCfg.url_strict} disabled={$taskRunning || testingApi} />
+              <span class="label-text text-xs text-base-content/60">{$t('config.api.urlStrict')}</span>
+            </label>
+            <p class="text-xs text-base-content/45 mb-1">{$t('config.api.urlStrictHint')}</p>
+            {#if resolvedChatURL}
+              <p class="text-xs text-base-content/50 break-all">
+                {$t('config.api.resolvedUrl')}: <code class="font-mono text-primary/80">{resolvedChatURL}</code>
+              </p>
+            {/if}
           </div>
           <div>
             <span class="text-xs text-base-content/50 mb-0.5 block">{$t('config.api.model')}</span>


### PR DESCRIPTION
## Summary
- Detect existing API version segments (e.g. `/v4`) and append `/chat/completions` without inserting `/v1`
- Add optional strict URL mode: only normalize trailing slashes and append `/chat/completions`
- Show the resolved request URL under the API base URL field in config
- Add Go tests and mirror the resolver in the frontend preview helper

## Test plan
- [x] `go test -run TestResolveChatCompletionsURL`
- [x] `go build` passes
- [ ] Configure `https://api.z.ai/api/paas/v4` and verify resolved endpoint is `.../v4/chat/completions`
- [ ] Enable strict mode with a custom base and confirm `/v1` is not inserted

Made with [Cursor](https://cursor.com)