### PR TITLE
feat: API 供应商预设与自定义模型输入

### DIFF
--- a/frontend/src/lib/i18n/en.js
+++ b/frontend/src/lib/i18n/en.js
@@ -278,7 +278,8 @@ export default {
 
   // ---- Config page ----
   'config.api.title': 'API config',
-  'config.api.baseUrl': 'API base URL',
+  'config.api.provider': 'API Provider',
+  'config.api.baseUrl': 'API Base URL',
   'config.api.urlStrict': 'Strict URL mode',
   'config.api.urlStrictHint': 'When enabled, /v1 is not added; only /chat/completions is appended.',
   'config.api.resolvedUrl': 'Resolved endpoint',

--- a/frontend/src/lib/i18n/zh.js
+++ b/frontend/src/lib/i18n/zh.js
@@ -282,6 +282,7 @@ export default {
 
   // ---- Config page ----
   'config.api.title': 'API 配置',
+  'config.api.provider': 'API 供应商',
   'config.api.baseUrl': 'API Base URL',
   'config.api.urlStrict': '严格 URL 模式',
   'config.api.urlStrictHint': '开启后不会自动插入 /v1，仅在末尾补 /chat/completions。',

--- a/frontend/src/pages/Config.svelte
+++ b/frontend/src/pages/Config.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import { api } from '../lib/api.js';
   import { apiConfig, config, progress, settings, editingCharID, editingWvID, wvFilter, addToast, showConfirm, taskRunning } from '../lib/stores.js';
   import { t } from '../lib/i18n/index.js';
@@ -40,7 +40,7 @@
   let localStoryCfg = { type: '', title: '', chapter_count: 30, target_words_per_chapter: 2500, writing_style: '', writing_pov: '', story_synopsis: '' };
   let testingApi = false;
   let selectedProvider = 'custom';
-  let selectedModel = '';
+  let providerSynced = false;
 
   const apiProviders = [
     { id: 'custom', label: '自定义', base_url: '', models: [] },
@@ -65,31 +65,27 @@
     return 'custom';
   }
 
-  function onProviderChange() {
-    const p = apiProviders.find(x => x.id === selectedProvider);
-    if (!p || p.id === 'custom') return;
+  function onProviderChange(e) {
+    const pid = e.currentTarget.value;
+    console.log('[DEBUG] Selected provider ID:', pid);
+    selectedProvider = pid;
+    const p = apiProviders.find(x => x.id === pid);
+    if (!p || p.id === 'custom') {
+      console.log('[DEBUG] Custom provider or not found, skipping update');
+      return;
+    }
+    console.log('[DEBUG] Updating base_url to:', p.base_url);
     localApiCfg.base_url = p.base_url;
+    console.log('[DEBUG] localApiCfg.base_url after update:', localApiCfg.base_url);
     if (p.models.length > 0 && !p.models.includes(localApiCfg.model)) {
       localApiCfg.model = p.models[0];
+      console.log('[DEBUG] Updating model to:', localApiCfg.model);
     }
-    selectedModel = localApiCfg.model;
-  }
-
-  function onModelChange() {
-    localApiCfg.model = selectedModel;
   }
 
   function syncProviderFromUrl() {
     const pid = detectProvider(localApiCfg.base_url);
     selectedProvider = pid;
-    if (pid !== 'custom') {
-      const p = apiProviders.find(x => x.id === pid);
-      selectedModel = (p && p.models.length > 0 && p.models.includes(localApiCfg.model))
-        ? localApiCfg.model
-        : (p?.models[0] || '');
-    } else {
-      selectedModel = localApiCfg.model;
-    }
   }
 
   $: currentProviderModels = (apiProviders.find(p => p.id === selectedProvider)?.models || []);
@@ -108,6 +104,10 @@
         url_strict: !!$apiConfig.url_strict,
       };
       apiCfgSnapshot = snap;
+      if (!providerSynced) {
+        providerSynced = true;
+        setTimeout(() => syncProviderFromUrl(), 0);
+      }
     }
   }
   $: if ($config?.story) {
@@ -454,14 +454,13 @@
           </div>
           <div>
             <span class="text-xs text-base-content/50 mb-0.5 block">{$t('config.api.model')}</span>
+            <input type="text" class="input input-sm w-full" bind:value={localApiCfg.model} list="model-suggestions" placeholder="gpt-4" disabled={$taskRunning || testingApi} />
             {#if currentProviderModels.length > 0}
-              <select class="select select-sm w-full" bind:value={selectedModel} on:change={onModelChange} disabled={$taskRunning || testingApi}>
+              <datalist id="model-suggestions">
                 {#each currentProviderModels as m}
                   <option value={m}>{m}</option>
                 {/each}
-              </select>
-            {:else}
-              <input type="text" class="input input-sm w-full" bind:value={localApiCfg.model} placeholder="gpt-4" disabled={$taskRunning || testingApi} />
+              </datalist>
             {/if}
           </div>
           <div>

--- a/frontend/src/pages/Config.svelte
+++ b/frontend/src/pages/Config.svelte
@@ -39,6 +39,60 @@
   let localApiCfg = { base_url: '', url_strict: false, model: '', api_key: '', http_timeout_seconds: 300, max_tokens: 0, context_budget_tokens: 900000 };
   let localStoryCfg = { type: '', title: '', chapter_count: 30, target_words_per_chapter: 2500, writing_style: '', writing_pov: '', story_synopsis: '' };
   let testingApi = false;
+  let selectedProvider = 'custom';
+  let selectedModel = '';
+
+  const apiProviders = [
+    { id: 'custom', label: '自定义', base_url: '', models: [] },
+    { id: 'openai', label: 'OpenAI', base_url: 'https://api.openai.com/v1', models: ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-3.5-turbo'] },
+    { id: 'anthropic', label: 'Anthropic', base_url: 'https://api.anthropic.com/v1', models: ['claude-sonnet-4-20250514', 'claude-3-5-sonnet-20241022', 'claude-3-haiku-20240307'] },
+    { id: 'google', label: 'Google Gemini', base_url: 'https://generativelanguage.googleapis.com/v1beta/openai', models: ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.0-flash'] },
+    { id: 'deepseek', label: 'DeepSeek', base_url: 'https://api.deepseek.com/v1', models: ['deepseek-chat', 'deepseek-reasoner'] },
+    { id: 'zhipu', label: '智谱AI', base_url: 'https://open.bigmodel.cn/api/paas/v4', models: ['glm-4-plus', 'glm-4', 'glm-4-flash', 'glm-4-air'] },
+    { id: 'qwen', label: '通义千问', base_url: 'https://dashscope.aliyuncs.com/compatible-mode/v1', models: ['qwen-plus', 'qwen-turbo', 'qwen-max', 'qwen-long'] },
+    { id: 'doubao', label: '豆包', base_url: 'https://ark.cn-beijing.volces.com/api/v3', models: ['doubao-pro-32k', 'doubao-pro-128k', 'doubao-lite-32k'] },
+    { id: 'moonshot', label: '月之暗面', base_url: 'https://api.moonshot.cn/v1', models: ['moonshot-v1-8k', 'moonshot-v1-32k', 'moonshot-v1-128k'] },
+    { id: 'siliconflow', label: '硅基流动', base_url: 'https://api.siliconflow.cn/v1', models: ['deepseek-ai/DeepSeek-V3', 'deepseek-ai/DeepSeek-R1', 'Qwen/Qwen2.5-72B-Instruct'] },
+  ];
+
+  function detectProvider(url) {
+    const u = (url || '').trim().replace(/\/+$/, '');
+    for (const p of apiProviders) {
+      if (p.id === 'custom') continue;
+      const pb = p.base_url.replace(/\/+$/, '');
+      if (u === pb || u.startsWith(pb + '/')) return p.id;
+    }
+    return 'custom';
+  }
+
+  function onProviderChange() {
+    const p = apiProviders.find(x => x.id === selectedProvider);
+    if (!p || p.id === 'custom') return;
+    localApiCfg.base_url = p.base_url;
+    if (p.models.length > 0 && !p.models.includes(localApiCfg.model)) {
+      localApiCfg.model = p.models[0];
+    }
+    selectedModel = localApiCfg.model;
+  }
+
+  function onModelChange() {
+    localApiCfg.model = selectedModel;
+  }
+
+  function syncProviderFromUrl() {
+    const pid = detectProvider(localApiCfg.base_url);
+    selectedProvider = pid;
+    if (pid !== 'custom') {
+      const p = apiProviders.find(x => x.id === pid);
+      selectedModel = (p && p.models.length > 0 && p.models.includes(localApiCfg.model))
+        ? localApiCfg.model
+        : (p?.models[0] || '');
+    } else {
+      selectedModel = localApiCfg.model;
+    }
+  }
+
+  $: currentProviderModels = (apiProviders.find(p => p.id === selectedProvider)?.models || []);
 
   $: resolvedChatURL = resolveChatCompletionsURL(localApiCfg.base_url, !!localApiCfg.url_strict);
 
@@ -377,6 +431,14 @@
         <h3 class="card-title text-base">{$t('config.api.title')}</h3>
         <div class="grid grid-cols-2 gap-x-3 gap-y-1.5">
           <div class="col-span-2">
+            <span class="text-xs text-base-content/50 mb-0.5 block">{$t('config.api.provider')}</span>
+            <select class="select select-sm w-full" bind:value={selectedProvider} on:change={onProviderChange} disabled={$taskRunning || testingApi}>
+              {#each apiProviders as p}
+                <option value={p.id}>{p.label}</option>
+              {/each}
+            </select>
+          </div>
+          <div class="col-span-2">
             <span class="text-xs text-base-content/50 mb-0.5 block">{$t('config.api.baseUrl')}</span>
             <input type="text" class="input input-sm w-full" bind:value={localApiCfg.base_url} placeholder="https://api.openai.com/v1" disabled={$taskRunning || testingApi} />
             <label class="label cursor-pointer justify-start gap-2 py-1 px-0 min-h-0">
@@ -392,7 +454,15 @@
           </div>
           <div>
             <span class="text-xs text-base-content/50 mb-0.5 block">{$t('config.api.model')}</span>
-            <input type="text" class="input input-sm w-full" bind:value={localApiCfg.model} placeholder="gpt-4" disabled={$taskRunning || testingApi} />
+            {#if currentProviderModels.length > 0}
+              <select class="select select-sm w-full" bind:value={selectedModel} on:change={onModelChange} disabled={$taskRunning || testingApi}>
+                {#each currentProviderModels as m}
+                  <option value={m}>{m}</option>
+                {/each}
+              </select>
+            {:else}
+              <input type="text" class="input input-sm w-full" bind:value={localApiCfg.model} placeholder="gpt-4" disabled={$taskRunning || testingApi} />
+            {/if}
           </div>
           <div>
             <span class="text-xs text-base-content/50 mb-0.5 block">{$t('config.api.timeout')}</span>


### PR DESCRIPTION
关于[#47](https://github.com/Nigh/show-me-the-story/pull/47)的commit 4重新做了修改

新增 API 供应商预设功能，支持快速选择供应商和模型建议，同时允许用户自定义输入模型名称。

### 功能特性
1. **供应商快速选择** — 下拉菜单预设 10 个主流供应商，选择后自动填充 Base URL 并推荐模型。
2. **自定义模型输入** — 用户可从建议列表中选择，也可直接输入任意模型名称。
3. **自动检测** — 加载配置时根据已保存的 Base URL 自动识别供应商。

### 变更文件
- `frontend/src/pages/Config.svelte` — 供应商下拉、模型 datalist、自动检测逻辑
- `frontend/src/lib/i18n/zh.js` — 中文翻译
- `frontend/src/lib/i18n/en.js` — 英文翻译

但是我觉得这个功能还能再优化，比如自定义模型可以联机获取，拉取最新的模型。