### PR TITLE
v3 M0: per-chapter file storage + lean progress API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,9 @@ task dev                              # 编译并启动 Go 后端
 |------|------|
 | `main.go` | 入口，确定程序目录（`progDir`），创建 `storys/` 目录，加载 API 配置，启动 Web 服务器（无项目选择状态）；`var version = "dev"` 通过 CI `-ldflags` 注入实际版本号 |
 | `config.go` | `APIConfig`（含 `URLStrict` 严格 URL 模式、`ContextBudgetTokens` 全书优化上下文预算）、`Config`（含 `SkillConfig` + `Language`）、`StoryConfig`、`PromptsConfig` 结构体，Load/Save 函数，`DefaultConfigForLang(lang)`、`NormalizeLanguage`、`applyDefaults(lang)` 按语言选择默认 prompts |
-| `state.go` | `Progress`、`ChapterState`、`Foreshadow`、`MemoryEntry` 结构体，`LoadProgress`、`SaveProgress`（原子写入）、`ChapterMarkdownPath`、`SaveChapterMarkdown(projectDir, ...)`、`ForeshadowRoadmapPath`（项目目录 `Foreshadows.md`） |
+| `state.go` | `Progress`、`ChapterState`（含 `WordCount` 字数、`ContentRev` 内容修订号）、`Foreshadow`、`MemoryEntry`（含 API 响应专用 `Snippet`）结构体，`LoadProgress`、`SaveProgress`（v3 分文件存储，见 `storage.go`）、`ChapterMarkdownPath`、`SaveChapterMarkdown(projectDir, ...)`、`ForeshadowRoadmapPath`（项目目录 `Foreshadows.md`） |
+| `storage.go` | **v3 存储层**：章节正文按章存 `chapters/NNNNNN.json`，`progress.json` 只存元数据（不含正文）；`saveChapterFiles`（fnv 内容哈希脏检查，仅重写变更章节 + 清理孤儿文件）、`loadChapterContents`、`ResetProgressFiles`（重置进度含章节目录）、`progressView`（API 响应视图：剥离正文、附 `word_count`/`content_rev`、解析记忆 `snippet`） |
+| `storage_test.go` | 存储层单测：roundtrip、脏检查不重写未变章节、孤儿清理、`progressView` 剥离正文 |
 | `api.go` | `resolveChatCompletionsURL`/`normalizeURL`（`url_strict` 时仅补 `/chat/completions`；否则路径含 `/vN` 只补 `/chat/completions`，裸域名补 `/v1/chat/completions`）、`CompletionResult`（含 `FinishReason`）、`CallAPI`/`CallAPIMessages`（**内部优先流式缓冲**，失败时回退 `callAPIMessagesSync`）、`CallAPIStream`/`CallAPIStreamMessages`（流式，解析 `finish_reason` + `stream_options.include_usage`）、`CallAPIWithRetry`/`CallAPIWithRetryLog`（无限重试）、`CallAPIStreamWithRetry`/`CallAPIStreamWithRetryLog`，`validateAPIConfig`、`isFatalAPIError`（401/403/404 致命，网络超时可重试）；所有调用经 `taskCtx` 时自动累计 token（优先 API `usage`，否则 rune 估算） |
 | `api_url_test.go` | `resolveChatCompletionsURL` 表驱动测试（z.ai v4、strict、DeepSeek、完整 URL） |
 | `outline.go` | `generateOutline`（注入 settings 角色列表 + 按 `target_words_per_chapter` 计算大纲字数下限，不足时自动重试）、`reviseOutline`、`GenerateOutlineAction`（存在已确认章节时拒绝整体重新生成；完成后 `runOutlinePostProcessChecks`）、`ReviseOutlineAction`、`ConfirmOutlineAction`、`EditChapterOutline`、`cleanJSONResponse` |
@@ -139,10 +141,10 @@ task dev                              # 编译并启动 Go 后端
 | `src/pages/Config.svelte` | 配置页：API 配置（含 `url_strict` 严格 URL 模式、解析后 endpoint 预览、上下文预算 tokens）、故事配置（直接 PUT 保存 + 关键设定变更时提示协调）、写作风格与叙述视角、AI 配置变更确认面板（`ConfigChangePanel`）、角色管理、世界观管理、组织管理（卡片 + 成员勾选）、关系管理（卡片 + 源/目标实体选择）；任务运行时所有输入控件禁用 |
 | `src/pages/Outline.svelte` | 大纲页：直接操作按钮（生成/确认/修订意见/删除/生成后续大纲）+ 导入续写 + pending 章节内联编辑 + 流式预览 + 标题/梗概展示优先 config（`preferUserValue` 一致）+ `ConfigChangePanel` + 未登记大纲人物确认面板（SSE `outline_character_suggestions`） |
 | `src/components/ConfigChangePanel.svelte` | AI 配置变更确认面板：展示 pending 提案（当前 vs 建议）、勾选采纳 / 全部忽略；SSE `config_change_proposal` 触发 |
-| `src/pages/Writing.svelte` | 写作页：章节列表（状态点）+ 直接操作（生成/确认/修改意见/去AI味，自动区分当前章修订与定向修订）+ 正文框选后浮动「引用到修改意见」按钮（插入 `> ` 引用行，触发段落级修订）+ 事实核查冲突处理面板（`pending_writing_conflict`，可选修改大纲/伏笔/重试/保留稿进入审核）+ 自动确认模式开关（toggle，随时可开关）+ 伏笔追踪摘要卡片（活跃/超期/临近回收）+ 优化章节衔接（进度卡片工具栏小按钮，已确认 ≥ 2 章时显示）+ 导出 TXT + 复制 + 上下章导航 + 流式尾部窗口展示（含「仅显示最新内容」提示；任务进行中当前章显示 taskTokenUsage，空闲时以 `countProseUnits` 显示正文字数）+ rAF 自动滚动（自动确认模式下自动跟随正在生成的章节）+ 全书完成后展示 `PostProcessPanel` |
+| `src/pages/Writing.svelte` | 写作页（v3：正文按需经 `GET /api/chapters/{num}` 拉取，`content_rev` 变化时刷新缓存；字数展示用索引里的 `word_count`；导出走 `GET /api/export/txt`）：章节列表（状态点）+ 直接操作（生成/确认/修改意见/去AI味，自动区分当前章修订与定向修订）+ 正文框选后浮动「引用到修改意见」按钮（插入 `> ` 引用行，触发段落级修订）+ 事实核查冲突处理面板（`pending_writing_conflict`，可选修改大纲/伏笔/重试/保留稿进入审核）+ 自动确认模式开关（toggle，随时可开关）+ 伏笔追踪摘要卡片（活跃/超期/临近回收）+ 优化章节衔接（进度卡片工具栏小按钮，已确认 ≥ 2 章时显示）+ 导出 TXT + 复制 + 上下章导航 + 流式尾部窗口展示（含「仅显示最新内容」提示；任务进行中当前章显示 taskTokenUsage，空闲时以 `countProseUnits` 显示正文字数）+ rAF 自动滚动（自动确认模式下自动跟随正在生成的章节）+ 全书完成后展示 `PostProcessPanel` |
 | `src/components/TaskTokenBadge.svelte` | 任务 token 展示（`↑ prompt ↓ completion tokens`）；对 `taskTokenUsage` 更新做线性 rAF 插值，动画时长 = `TOKEN_POLL_INTERVAL_MS`；目标值低于当前显示值时该维度从 0 重新向上插值（新一段统计或估算修正）；供 ChatPanel / App 顶栏 / Writing 页复用 |
 | `src/pages/Foreshadows.svelte` | 伏笔页：统计概览 + AI 设计伏笔 + 手动 CRUD + AI 建议确认面板（SSE `foreshadow_suggestions`）+ 伏笔-大纲冲突报告卡片（`last_foreshadow_outline_report`）+ 列表/章节时间线/路线图文档三视图 + 复制/下载 `Foreshadows.md` |
-| `src/pages/Memory.svelte` | 叙事记忆页（只读）：从 `progress.memory_entries` 展示统计（条数/覆盖章节/token 上限/内容字数）+ 列表/按章节时间线两视图 + 分类/章节筛选 + 原文片段预览（按段落位置从章节正文截取）+ 刷新/复制 |
+| `src/pages/Memory.svelte` | 叙事记忆页（只读）：从 `progress.memory_entries` 展示统计（条数/覆盖章节/token 上限/内容字数）+ 列表/按章节时间线两视图 + 分类/章节筛选 + 原文片段预览（v3：片段由后端在 `snippet` 字段解析下发）+ 刷新/复制 |
 | `src/components/PostProcessPanel.svelte` | 全书优化面板：开始全书分析（诊断+核查+路线图）/ 重新核查 / 重新生成路线图 / 清空；诊断与核查报告 Markdown 展示；优化工单表格（勾选、编辑意见、执行选项、diff 对比弹窗） |
 | `src/pages/Relations.svelte` | 图谱页：Canvas 力导向图谱（ForceGraph 类），支持拖拽、滚轮缩放（以光标为中心，0.3x–3x）、hover 高亮（强调 hover 节点与其连线，次强调直接相邻节点，其余淡化） |
 | `src/pages/Assistant.svelte` | 助理页：聊天会话列表 + 消息区 + 工具调用卡片 + 流式回复 |
@@ -356,9 +358,16 @@ pending → writing → review → accepted
 
 前端「记忆」页（`#memory`）只读展示 `memory_entries`：统计概览、列表/按章节时间线、分类与章节筛选、原文片段预览；数据来自 `GET /api/progress`（无独立 API）。
 
-### 进度持久化
+### 进度持久化（v3 分文件存储）
 
-每个关键步骤后立即保存 `progress.json`。API 配置保存 `api.json`，故事配置保存 `config.json`。设定保存 `settings.json`。使用原子写入（先写 `.tmp` 再 rename）。
+每个关键步骤后立即调用 `SaveProgress`。v3 起章节正文与元数据分离：
+
+- `progress.json`：项目元数据（phase、标题、章节列表**不含正文**、伏笔、记忆等）
+- `chapters/NNNNNN.json`：每章一个文件（num/title/content），`SaveProgress` 内部用 fnv 哈希做脏检查，只重写内容变化的章节，并清理孤儿章节文件
+- 内存模型不变：`Progress.Chapters[].Content` 加载后常驻内存，所有业务代码照旧读写
+- `GET /api/progress` 返回 `progressView`（正文剥离，携带 `word_count` 与 `content_rev`），正文经 `GET /api/chapters/{num}` 按需拉取；前端用 `content_rev` 失效缓存
+
+API 配置保存 `api.json`，故事配置保存 `config.json`。设定保存 `settings.json`。使用原子写入（先写 `.tmp` 再 rename）。
 
 ### 结构化设定
 
@@ -435,8 +444,10 @@ pending → writing → review → accepted
 | GET | `/api/config/pending-changes` | 同步 | 获取 AI 待确认配置变更提案 |
 | POST | `/api/config/apply-changes` | 同步 | 采纳选中的 pending 配置变更 |
 | DELETE | `/api/config/pending-changes` | 同步 | 清空 pending 配置变更提案 |
-| GET | `/api/progress` | 同步 | 获取进度 |
-| DELETE | `/api/progress` | 同步 | 重置进度 |
+| GET | `/api/progress` | 同步 | 获取进度（v3：章节不含正文，含 `word_count`/`content_rev`） |
+| GET | `/api/chapters/{num}` | 同步 | 获取单章完整正文 |
+| GET | `/api/export/txt` | 同步 | 导出全书 TXT（text/plain） |
+| DELETE | `/api/progress` | 同步 | 重置进度（含 `chapters/` 目录） |
 | GET | `/api/status` | 同步 | 获取状态摘要 |
 | POST | `/api/outline/generate` | 异步 | 生成大纲（存在已确认章节时返回 409 拒绝） |
 | POST | `/api/outline/confirm` | 同步 | 确认大纲 |

--- a/agent.go
+++ b/agent.go
@@ -2055,7 +2055,7 @@ func getBuiltinTools() []Tool {
 				if msg := requireConfirm(ctx, args, fmt.Sprintf("重置全部进度（共 %d 章及所有伏笔）", len(ctx.State.Chapters))); msg != "" {
 					return msg, nil
 				}
-				if err := deleteFile(ctx.ProgressPath); err != nil {
+				if err := ResetProgressFiles(ctx.ProgressPath); err != nil {
 					return "", agentErr(ctx, "delete_progress_failed", err)
 				}
 				// 原地清空，保证 Handlers 持有的同一指针也被重置

--- a/frontend/src/components/PostProcessPanel.svelte
+++ b/frontend/src/components/PostProcessPanel.svelte
@@ -7,7 +7,7 @@
 
   $: bookComplete = (() => {
     const chs = $progress?.chapters || [];
-    return chs.length > 0 && chs.every(c => c.status === 'accepted' && c.content);
+    return chs.length > 0 && chs.every(c => c.status === 'accepted' && c.content_rev);
   })();
 
   $: pp = $postprocess?.state;

--- a/frontend/src/pages/Memory.svelte
+++ b/frontend/src/pages/Memory.svelte
@@ -33,17 +33,9 @@
   });
   $: timelineRows = buildTimeline(filtered);
 
-  function extractSnippet(chapterNum, position, maxRunes = 100) {
-    if (!position || !chapterNum) return '';
-    const ch = chapters.find(c => c.num === chapterNum);
-    if (!ch?.content) return '';
-    const paragraphs = ch.content.split('\n\n');
-    const idx = position - 1;
-    if (idx < 0 || idx >= paragraphs.length) return '';
-    const para = paragraphs[idx].trim();
-    const runes = [...para];
-    if (runes.length > maxRunes) return runes.slice(0, maxRunes).join('') + '…';
-    return para;
+  // v3: 原文片段由后端在 /api/progress 中直接解析（正文不再随 progress 下发）
+  function extractSnippet(entry) {
+    return entry?.snippet || '';
   }
 
   function buildTimeline(items) {
@@ -63,7 +55,7 @@
   }
 
   function formatEntryLine(e) {
-    const snippet = extractSnippet(e.chapter, e.position);
+    const snippet = extractSnippet(e);
     if (snippet) {
       return `[第${e.chapter}章] ${e.content}（原文：「${snippet}」）`;
     }
@@ -172,7 +164,7 @@
               </thead>
               <tbody>
                 {#each filtered as e (e.id)}
-                  {@const snippet = extractSnippet(e.chapter, e.position)}
+                  {@const snippet = extractSnippet(e)}
                   <tr>
                     <td class="font-mono text-xs">{e.id}</td>
                     <td>
@@ -208,7 +200,7 @@
                 </div>
                 <div class="space-y-2">
                   {#each row.entries as e (e.id)}
-                    {@const snippet = extractSnippet(e.chapter, e.position)}
+                    {@const snippet = extractSnippet(e)}
                     <div class="rounded-md bg-base-200/80 px-3 py-2 text-sm">
                       <div class="flex flex-wrap items-center gap-2 mb-1">
                         <span class="font-mono text-xs text-base-content/50">#{e.id}</span>

--- a/frontend/src/pages/Writing.svelte
+++ b/frontend/src/pages/Writing.svelte
@@ -54,11 +54,30 @@
   $: ch = $selectedChapter >= 0 && $selectedChapter < chapters.length ? chapters[$selectedChapter] : null;
   $: isCurrent = ch && currentIdx === $selectedChapter;
   $: isStreamingThis = $streamingChapterIdx === $selectedChapter && $streamingContent;
-  // 流式期间 $streamingContent 只含尾部窗口（性能保护），全文在生成结束后由 progress 拉取
-  $: displayContent = isStreamingThis ? $streamingContent : (ch?.content || '');
-  $: chapterWordCount = ch?.content ? countProseUnits(ch.content) : 0;
+
+  // v3: /api/progress 不再携带正文，选中章节的正文按需拉取，content_rev 变化时刷新
+  let chapterContent = '';
+  let loadedNum = -1;
+  let loadedRev = null;
+  $: if (ch) maybeLoadContent(ch);
+  async function maybeLoadContent(c) {
+    const rev = c.content_rev || '';
+    if (c.num === loadedNum && rev === loadedRev) return;
+    loadedNum = c.num;
+    loadedRev = rev;
+    if (!rev) { chapterContent = ''; return; }
+    try {
+      const full = await api('GET', '/api/chapters/' + c.num);
+      if (loadedNum === c.num) chapterContent = full.content || '';
+    } catch (e) {}
+  }
+  $: hasContent = !!(ch?.content_rev);
+
+  // 流式期间 $streamingContent 只含尾部窗口（性能保护），全文在生成结束后按需拉取
+  $: displayContent = isStreamingThis ? $streamingContent : chapterContent;
+  $: chapterWordCount = ch?.word_count || (chapterContent ? countProseUnits(chapterContent) : 0);
   $: showTaskTokens = $taskRunning && isCurrent;
-  $: totalWords = chapters.reduce((sum, c) => sum + (c.content ? countProseUnits(c.content) : 0), 0);
+  $: totalWords = chapters.reduce((sum, c) => sum + (c.word_count || 0), 0);
 
   $: foreshadows = p?.foreshadows || [];
   $: fsActive = foreshadows.filter(f => f.status === 'planted' || f.status === 'progressing');
@@ -233,29 +252,27 @@
   }
 
   async function copyContent() {
-    if (!ch?.content) return;
+    if (!chapterContent) return;
     try {
-      await navigator.clipboard.writeText(ch.content);
+      await navigator.clipboard.writeText(chapterContent);
       addToast($t('writing.toasts.copied'), 'success');
     } catch (e) { addToast($t('common.copy.failed'), 'error'); }
   }
 
-  function exportBook() {
-    const written = chapters.filter(c => c.content);
+  async function exportBook() {
+    const written = chapters.filter(c => c.content_rev);
     if (written.length === 0) { addToast($t('writing.toasts.exportEmpty'), 'error'); return; }
-    const titleStr = p.title || $t('common.untitled');
-    const parts = [$t('writing.export.bookTitle', { title: titleStr }) + '\n'];
-    for (const c of written) {
-      parts.push('\n\n' + $t('writing.export.chapterHeader', { num: c.num, title: c.title }) + '\n\n' + c.content);
-    }
-    const blob = new Blob([parts.join('')], { type: 'text/plain;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${p.title || $t('writing.export.defaultName')}.txt`;
-    a.click();
-    URL.revokeObjectURL(url);
-    addToast($t('writing.toasts.exportDone', { n: written.length }), 'success');
+    try {
+      const r = await fetch('/api/export/txt');
+      const blob = await r.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${p.title || $t('writing.export.defaultName')}.txt`;
+      a.click();
+      URL.revokeObjectURL(url);
+      addToast($t('writing.toasts.exportDone', { n: written.length }), 'success');
+    } catch (e) { addToast(e.message, 'error'); }
   }
 
   function prevChapter() { if ($selectedChapter > 0) selectChapter($selectedChapter - 1); }
@@ -463,7 +480,7 @@
                 {#if ch.status === 'review' && isCurrent}
                   <button class="btn btn-success btn-sm" on:click={doConfirm} disabled={$taskRunning}>{$t('writing.btn.confirm')}</button>
                 {/if}
-                {#if ch.content && ch.status !== 'writing'}
+                {#if hasContent && ch.status !== 'writing'}
                   <button class="btn btn-ghost btn-sm" on:click={() => showRevise = !showRevise} disabled={$taskRunning}>{$t('writing.btn.revise')}</button>
                   {#if hasPolishSkills}
                     <button class="btn btn-ghost btn-sm" on:click={doPolish} disabled={$taskRunning} title={$t('writing.btn.polish.tip')}>{$t('writing.btn.polish')}</button>

--- a/handlers.go
+++ b/handlers.go
@@ -455,7 +455,52 @@ func (h *Handlers) DeletePendingConfigChanges(w http.ResponseWriter, r *http.Req
 }
 
 func (h *Handlers) GetProgress(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(w, http.StatusOK, h.state)
+	h.writeJSON(w, http.StatusOK, progressView(h.state))
+}
+
+// GetChapterContent returns one chapter with full prose content.
+func (h *Handlers) GetChapterContent(w http.ResponseWriter, r *http.Request) {
+	numStr := r.PathValue("num")
+	var num int
+	if _, err := fmt.Sscanf(numStr, "%d", &num); err != nil {
+		h.writeErrorReq(w, r, http.StatusBadRequest, "invalid_chapter_num")
+		return
+	}
+	idx := findChapterIdx(h.state, num)
+	if idx < 0 {
+		h.writeErrorReq(w, r, http.StatusNotFound, "chapter_n_not_found", num)
+		return
+	}
+	ch := h.state.Chapters[idx]
+	if ch.Content != "" {
+		ch.WordCount = countProseUnits(ch.Content)
+		ch.ContentRev = fmt.Sprintf("%x", hashContent(ch.Content))
+	}
+	h.writeJSON(w, http.StatusOK, ch)
+}
+
+// GetBookExport streams the whole book as plain text.
+func (h *Handlers) GetBookExport(w http.ResponseWriter, r *http.Request) {
+	lang := LangZH
+	if h.cfg != nil {
+		lang = NormalizeLanguage(h.cfg.Language)
+	}
+	title := h.state.Title
+	if title == "" {
+		title = h.projectName
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprintf(w, "%s\n", title)
+	for _, ch := range h.state.Chapters {
+		if ch.Content == "" {
+			continue
+		}
+		if lang == LangEN {
+			fmt.Fprintf(w, "\n\nChapter %d: %s\n\n%s", ch.Num, ch.Title, ch.Content)
+		} else {
+			fmt.Fprintf(w, "\n\n第 %d 章 %s\n\n%s", ch.Num, ch.Title, ch.Content)
+		}
+	}
 }
 
 func (h *Handlers) DeleteProgress(w http.ResponseWriter, r *http.Request) {
@@ -464,13 +509,13 @@ func (h *Handlers) DeleteProgress(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := deleteFile(h.progressPath); err != nil {
+	if err := ResetProgressFiles(h.progressPath); err != nil {
 		h.writeErrorReq(w, r, http.StatusInternalServerError, "delete_progress_failed", err.Error())
 		return
 	}
 
 	h.state = &Progress{Phase: "outline"}
-	h.writeJSON(w, http.StatusOK, h.state)
+	h.writeJSON(w, http.StatusOK, progressView(h.state))
 }
 
 func (h *Handlers) PostOutlineGenerate(w http.ResponseWriter, r *http.Request) {
@@ -569,7 +614,7 @@ func (h *Handlers) PostOutlineConfirm(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.logger.SuccessKey("log.outline_confirmed")
-	h.writeJSON(w, http.StatusOK, h.state)
+	h.writeJSON(w, http.StatusOK, progressView(h.state))
 }
 
 func (h *Handlers) PostOutlineRevise(w http.ResponseWriter, r *http.Request) {
@@ -786,7 +831,7 @@ func (h *Handlers) PostChapterConflictResolve(w http.ResponseWriter, r *http.Req
 		}
 		h.logger.SuccessKey("log.chapter_kept_review", ch.Num)
 		h.broadcastProgress()
-		h.writeJSON(w, http.StatusOK, h.state)
+		h.writeJSON(w, http.StatusOK, progressView(h.state))
 	case "dismiss":
 		h.state.PendingWritingConflict = nil
 		if err := SaveProgress(h.progressPath, h.state); err != nil {
@@ -794,7 +839,7 @@ func (h *Handlers) PostChapterConflictResolve(w http.ResponseWriter, r *http.Req
 			return
 		}
 		h.broadcastProgress()
-		h.writeJSON(w, http.StatusOK, h.state)
+		h.writeJSON(w, http.StatusOK, progressView(h.state))
 	case "retry":
 		h.state.PendingWritingConflict = nil
 		if err := SaveProgress(h.progressPath, h.state); err != nil {
@@ -849,7 +894,7 @@ func (h *Handlers) PostChapterConfirm(w http.ResponseWriter, r *http.Request) {
 
 	ch := h.state.Chapters[h.state.CurrentChapterIndex-1]
 	h.logger.SuccessKey("log.chapter_confirmed", ch.Num)
-	h.writeJSON(w, http.StatusOK, h.state)
+	h.writeJSON(w, http.StatusOK, progressView(h.state))
 }
 
 func (h *Handlers) PostChapterEdit(w http.ResponseWriter, r *http.Request) {
@@ -1066,7 +1111,7 @@ func (h *Handlers) DeleteChapter(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.logger.SuccessKey("log.chapter_deleted", num)
-	h.writeJSON(w, http.StatusOK, h.state)
+	h.writeJSON(w, http.StatusOK, progressView(h.state))
 }
 
 func (h *Handlers) DeleteOutline(w http.ResponseWriter, r *http.Request) {
@@ -1095,7 +1140,7 @@ func (h *Handlers) DeleteOutline(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.logger.SuccessKey("log.outline_deleted")
-	h.writeJSON(w, http.StatusOK, h.state)
+	h.writeJSON(w, http.StatusOK, progressView(h.state))
 }
 
 func (h *Handlers) PutChapterOutline(w http.ResponseWriter, r *http.Request) {
@@ -1133,7 +1178,7 @@ func (h *Handlers) PutChapterOutline(w http.ResponseWriter, r *http.Request) {
 	go RunForeshadowOutlineCheckAndSave(context.Background(), h.apiCfg, h.cfg, h.state, h.progressPath, h.logger)
 
 	h.logger.SuccessKey("log.chapter_outline_updated", num)
-	h.writeJSON(w, http.StatusOK, h.state)
+	h.writeJSON(w, http.StatusOK, progressView(h.state))
 }
 
 func (h *Handlers) PostSettingsReconcile(w http.ResponseWriter, r *http.Request) {
@@ -1228,7 +1273,7 @@ func (h *Handlers) DeleteChaptersFrom(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.logger.SuccessKey("log.chapters_deleted_from", num, deletedCount)
-	h.writeJSON(w, http.StatusOK, h.state)
+	h.writeJSON(w, http.StatusOK, progressView(h.state))
 }
 
 func (h *Handlers) broadcastProgress() {
@@ -1601,7 +1646,7 @@ func (h *Handlers) PostContinueConfirm(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.logger.SuccessKey("log.continue_import_done")
-	h.writeJSON(w, http.StatusOK, h.state)
+	h.writeJSON(w, http.StatusOK, progressView(h.state))
 }
 
 func (h *Handlers) PostOutlineGenerateContinuation(w http.ResponseWriter, r *http.Request) {

--- a/state.go
+++ b/state.go
@@ -11,9 +11,15 @@ type ChapterState struct {
 	Num     int    `json:"num"`
 	Title   string `json:"title"`
 	Outline string `json:"outline"`
-	Content string `json:"content"`
+	Content string `json:"content,omitempty"`
 	Summary string `json:"summary"`
 	Status  string `json:"status"` // pending | writing | review | accepted
+	// WordCount is the prose-unit count of Content, refreshed on save so the
+	// frontend can show word counts without fetching full chapter content.
+	WordCount int `json:"word_count,omitempty"`
+	// ContentRev is a content hash for API responses; the frontend uses it to
+	// invalidate its per-chapter content cache. Never persisted.
+	ContentRev string `json:"content_rev,omitempty"`
 }
 
 type ForeshadowStatus string
@@ -78,6 +84,9 @@ type MemoryEntry struct {
 	Category string `json:"category"` // character | location | item | event | promise | other
 	Chapter  int    `json:"chapter"`
 	Position int    `json:"position"`
+	// Snippet is resolved server-side for API responses (chapter content no
+	// longer travels with /api/progress); never persisted.
+	Snippet string `json:"snippet,omitempty"`
 }
 
 type Progress struct {
@@ -103,6 +112,8 @@ const (
 	StatusAccepted = "accepted"
 )
 
+// LoadProgress loads project metadata from path (progress.json) and chapter
+// prose from the chapters/ directory next to it (v3 storage layout).
 func LoadProgress(path string) (*Progress, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -117,11 +128,25 @@ func LoadProgress(path string) (*Progress, error) {
 		return nil, fmt.Errorf("解析进度文件失败: %w", err)
 	}
 
+	loadChapterContents(path, &p)
 	return &p, nil
 }
 
+// SaveProgress persists chapter prose to per-chapter files (only chapters
+// whose content changed since load/last save are rewritten), then writes the
+// metadata file without prose content.
 func SaveProgress(path string, p *Progress) error {
-	data, err := json.MarshalIndent(p, "", "  ")
+	if err := saveChapterFiles(path, p); err != nil {
+		return err
+	}
+
+	meta := *p
+	meta.Chapters = make([]ChapterState, len(p.Chapters))
+	for i, ch := range p.Chapters {
+		ch.Content = ""
+		meta.Chapters[i] = ch
+	}
+	data, err := json.MarshalIndent(&meta, "", "  ")
 	if err != nil {
 		return fmt.Errorf("序列化进度失败: %w", err)
 	}

--- a/storage.go
+++ b/storage.go
@@ -1,0 +1,185 @@
+package main
+
+// v3 project storage: progress metadata lives in project.json (chapter list
+// WITHOUT prose content), each chapter's prose lives in chapters/NNNNNN.json.
+// LoadProgress/SaveProgress keep their v2 signatures (path = project.json) so
+// every caller stays untouched; the split happens inside.
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// chapterFile is the on-disk shape of chapters/NNNNNN.json.
+type chapterFile struct {
+	Num     int    `json:"num"`
+	Title   string `json:"title"`
+	Content string `json:"content"`
+}
+
+func chaptersDir(progressPath string) string {
+	return filepath.Join(filepath.Dir(progressPath), "chapters")
+}
+
+func chapterFilePath(progressPath string, num int) string {
+	return filepath.Join(chaptersDir(progressPath), fmt.Sprintf("%06d.json", num))
+}
+
+// contentHashCache tracks the last-saved content hash per project per chapter,
+// so SaveProgress only rewrites chapter files whose prose actually changed.
+// ponytail: process-global map, entries never evicted; bounded by number of
+// projects opened in one process lifetime, which is tiny.
+var contentHashCache = struct {
+	sync.Mutex
+	m map[string]map[int]uint64
+}{m: map[string]map[int]uint64{}}
+
+func hashContent(s string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(s))
+	return h.Sum64()
+}
+
+func cacheFor(progressPath string) map[int]uint64 {
+	contentHashCache.Lock()
+	defer contentHashCache.Unlock()
+	c, ok := contentHashCache.m[progressPath]
+	if !ok {
+		c = map[int]uint64{}
+		contentHashCache.m[progressPath] = c
+	}
+	return c
+}
+
+func resetCache(progressPath string) {
+	contentHashCache.Lock()
+	delete(contentHashCache.m, progressPath)
+	contentHashCache.Unlock()
+}
+
+// saveChapterFiles writes chapter files whose content changed since the last
+// load/save, removes orphaned chapter files, and refreshes WordCount.
+func saveChapterFiles(progressPath string, p *Progress) error {
+	dir := chaptersDir(progressPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("创建章节目录失败: %w", err)
+	}
+
+	cache := cacheFor(progressPath)
+	live := make(map[int]bool, len(p.Chapters))
+
+	for i := range p.Chapters {
+		ch := &p.Chapters[i]
+		live[ch.Num] = true
+		h := hashContent(ch.Content)
+		contentHashCache.Lock()
+		prev, seen := cache[ch.Num]
+		contentHashCache.Unlock()
+		if seen && prev == h {
+			continue
+		}
+		ch.WordCount = countProseUnits(ch.Content)
+		data, err := json.MarshalIndent(chapterFile{Num: ch.Num, Title: ch.Title, Content: ch.Content}, "", "  ")
+		if err != nil {
+			return fmt.Errorf("序列化第 %d 章失败: %w", ch.Num, err)
+		}
+		if err := writeFileAtomic(chapterFilePath(progressPath, ch.Num), data); err != nil {
+			return fmt.Errorf("保存第 %d 章失败: %w", ch.Num, err)
+		}
+		contentHashCache.Lock()
+		cache[ch.Num] = h
+		contentHashCache.Unlock()
+	}
+
+	// Remove orphaned chapter files (e.g. outline regenerated with fewer chapters).
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		var num int
+		if _, err := fmt.Sscanf(name, "%d.json", &num); err != nil {
+			continue
+		}
+		if !live[num] {
+			deleteFile(filepath.Join(dir, name))
+			contentHashCache.Lock()
+			delete(cache, num)
+			contentHashCache.Unlock()
+		}
+	}
+	return nil
+}
+
+// loadChapterContents fills Content for each chapter from its chapter file
+// and primes the dirty-check cache.
+func loadChapterContents(progressPath string, p *Progress) {
+	cache := cacheFor(progressPath)
+	for i := range p.Chapters {
+		ch := &p.Chapters[i]
+		data, err := os.ReadFile(chapterFilePath(progressPath, ch.Num))
+		if err != nil {
+			ch.Content = ""
+			continue
+		}
+		var cf chapterFile
+		if err := json.Unmarshal(data, &cf); err != nil {
+			ch.Content = ""
+			continue
+		}
+		ch.Content = cf.Content
+		if ch.WordCount == 0 && ch.Content != "" {
+			ch.WordCount = countProseUnits(ch.Content)
+		}
+		contentHashCache.Lock()
+		cache[ch.Num] = hashContent(ch.Content)
+		contentHashCache.Unlock()
+	}
+}
+
+// ResetProgressFiles removes project.json and the chapters directory.
+func ResetProgressFiles(progressPath string) error {
+	if err := deleteFile(progressPath); err != nil {
+		return err
+	}
+	resetCache(progressPath)
+	return os.RemoveAll(chaptersDir(progressPath))
+}
+
+// progressView returns a copy of p with prose content removed from chapters
+// (word count + content revision kept) and memory snippets resolved, for API
+// responses.
+func progressView(p *Progress) *Progress {
+	cp := *p
+	cp.Chapters = make([]ChapterState, len(p.Chapters))
+	for i, ch := range p.Chapters {
+		if ch.Content != "" {
+			if ch.WordCount == 0 {
+				ch.WordCount = countProseUnits(ch.Content)
+			}
+			ch.ContentRev = fmt.Sprintf("%x", hashContent(ch.Content))
+		} else {
+			ch.WordCount = 0
+		}
+		ch.Content = ""
+		cp.Chapters[i] = ch
+	}
+	if len(p.MemoryEntries) > 0 {
+		entries := make([]MemoryEntry, len(p.MemoryEntries))
+		for i, m := range p.MemoryEntries {
+			m.Snippet = extractSnippet(p, m.Chapter, m.Position, 100)
+			entries[i] = m
+		}
+		cp.MemoryEntries = entries
+	}
+	return &cp
+}

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStorageRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "progress.json")
+
+	p := &Progress{
+		Phase: "writing",
+		Title: "测试书",
+		Chapters: []ChapterState{
+			{Num: 1, Title: "第一章", Outline: "开局", Content: "第一段。\n\n第二段。", Summary: "摘要1", Status: StatusAccepted},
+			{Num: 2, Title: "第二章", Outline: "冲突", Content: "", Status: StatusPending},
+		},
+		CurrentChapterIndex: 1,
+		MemoryEntries: []MemoryEntry{
+			{ID: 1, Content: "主角捡到怀表", Category: "item", Chapter: 1, Position: 2},
+		},
+	}
+
+	if err := SaveProgress(path, p); err != nil {
+		t.Fatalf("SaveProgress: %v", err)
+	}
+
+	// Metadata file must not contain prose content.
+	meta, _ := os.ReadFile(path)
+	if strings.Contains(string(meta), "第一段。") {
+		t.Fatal("progress.json 不应包含正文")
+	}
+
+	// Chapter file exists with content.
+	if _, err := os.Stat(chapterFilePath(path, 1)); err != nil {
+		t.Fatalf("章节文件缺失: %v", err)
+	}
+
+	// Roundtrip restores content.
+	resetCache(path)
+	loaded, err := LoadProgress(path)
+	if err != nil {
+		t.Fatalf("LoadProgress: %v", err)
+	}
+	if loaded.Chapters[0].Content != "第一段。\n\n第二段。" {
+		t.Fatalf("正文丢失: %q", loaded.Chapters[0].Content)
+	}
+	if loaded.Chapters[0].WordCount == 0 {
+		t.Fatal("WordCount 未计算")
+	}
+	if loaded.Chapters[1].Content != "" {
+		t.Fatal("空章节不应有正文")
+	}
+}
+
+func TestSaveProgressDirtyCheck(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "progress.json")
+	p := &Progress{Phase: "writing", Chapters: []ChapterState{
+		{Num: 1, Title: "A", Content: "原文", Status: StatusAccepted},
+	}}
+	if err := SaveProgress(path, p); err != nil {
+		t.Fatal(err)
+	}
+	ch1 := chapterFilePath(path, 1)
+	st1, _ := os.Stat(ch1)
+
+	// Save again without changes: chapter file must not be rewritten.
+	// Corrupt-proof check: delete the file; unchanged content should be skipped
+	// only when hash cache says so — so instead compare mtime via rewrite marker.
+	os.Chtimes(ch1, st1.ModTime(), st1.ModTime())
+	if err := SaveProgress(path, p); err != nil {
+		t.Fatal(err)
+	}
+	st2, _ := os.Stat(ch1)
+	if !st2.ModTime().Equal(st1.ModTime()) {
+		t.Fatal("未变更的章节文件被重写")
+	}
+
+	// Change content: file must be rewritten.
+	p.Chapters[0].Content = "改过的正文"
+	if err := SaveProgress(path, p); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(ch1)
+	var cf chapterFile
+	json.Unmarshal(data, &cf)
+	if cf.Content != "改过的正文" {
+		t.Fatalf("章节文件未更新: %q", cf.Content)
+	}
+}
+
+func TestSaveProgressOrphanCleanup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "progress.json")
+	p := &Progress{Phase: "outline", Chapters: []ChapterState{
+		{Num: 1, Content: "a", Status: StatusPending},
+		{Num: 2, Content: "b", Status: StatusPending},
+	}}
+	if err := SaveProgress(path, p); err != nil {
+		t.Fatal(err)
+	}
+	p.Chapters = p.Chapters[:1]
+	if err := SaveProgress(path, p); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(chapterFilePath(path, 2)); !os.IsNotExist(err) {
+		t.Fatal("孤儿章节文件未清理")
+	}
+}
+
+func TestProgressViewStripsContent(t *testing.T) {
+	p := &Progress{Chapters: []ChapterState{
+		{Num: 1, Content: "正文内容", Status: StatusAccepted},
+	}}
+	v := progressView(p)
+	if v.Chapters[0].Content != "" {
+		t.Fatal("view 不应包含正文")
+	}
+	if v.Chapters[0].ContentRev == "" || v.Chapters[0].WordCount == 0 {
+		t.Fatal("view 应包含 content_rev 与 word_count")
+	}
+	if p.Chapters[0].Content == "" {
+		t.Fatal("原始 state 被破坏")
+	}
+}

--- a/web.go
+++ b/web.go
@@ -58,6 +58,8 @@ func startWebServer(apiCfg *APIConfig, apiCfgPath string, cfg *Config, state *Pr
 	mux.HandleFunc("POST /api/outline/characters/confirm", h.PostOutlineCharactersConfirm)
 	mux.HandleFunc("PUT /api/outline/{num}", h.PutChapterOutline)
 
+	mux.HandleFunc("GET /api/chapters/{num}", h.GetChapterContent)
+	mux.HandleFunc("GET /api/export/txt", h.GetBookExport)
 	mux.HandleFunc("POST /api/chapter/generate", h.PostChapterGenerate)
 	mux.HandleFunc("GET /api/chapter/conflict", h.GetChapterConflict)
 	mux.HandleFunc("POST /api/chapter/conflict-resolve", h.PostChapterConflictResolve)


### PR DESCRIPTION
## Summary
- progress.json 只存元数据，章节正文按章存 chapters/NNNNNN.json（fnv 哈希脏检查，仅重写变更章节，自动清理孤儿文件）
- GET /api/progress 剥离正文，携带 word_count + content_rev；新增 GET /api/chapters/{num}（单章正文）与 GET /api/export/txt（全书导出）
- 前端写作页按需拉取选中章正文（content_rev 失效缓存）；记忆页原文片段由后端 snippet 字段下发；全书优化面板用 content_rev 判断完成度

## Test plan
- [x] go test ./...（62 通过，新增 storage_test.go：roundtrip / 脏检查 / 孤儿清理 / progressView）
- [x] npm run build + go build 通过
- [x] 冒烟测试：启动服务 → 创建/切换项目 → /api/progress /api/chapters/1 /api/export/txt 全部符合预期

Made with [Cursor](https://cursor.com)