### PR TITLE
feat: persist LLM connection test result on config page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,14 +125,14 @@ main.go                      入口：progDir 解析、api.json 加载、//go:em
 | `src/lib/apiUrl.js` | `resolveChatCompletionsURL`：与后端 `api.go` 同逻辑的 URL 预览（配置页展示实际请求地址） |
 | `src/lib/api.js` | `api(method, url, body)` — fetch 封装，自动带 `X-UI-Locale`/`Accept-Language` 头，错误消息走 `translateServerMessage` |
 | `src/lib/router.js` | `currentPage` store + hash 路由监听 |
-| `src/lib/stores.js` | 全局 Svelte stores（progress、config、settings、postprocess、taskRunning、taskTokenUsage、autoConfirm、lastFailedTask、`projectLanguage`、`pendingConfigChanges`/`showConfigChangePanel` 等）+ toast/log 管理 |
+| `src/lib/stores.js` | 全局 Svelte stores（progress、config、settings、postprocess、taskRunning、taskTokenUsage、autoConfirm、lastFailedTask、`projectLanguage`、`pendingConfigChanges`/`showConfigChangePanel`、`apiTestResult` LLM 连接测试结果持久化 等）+ toast/log 管理 |
 | `src/lib/proseUnits.js` | `countProseUnits`：与后端 `prose_units.go` 同口径，供写作页章节/全书字数展示 |
 | `src/lib/tokenPoll.js` | `TOKEN_POLL_INTERVAL_MS`：token poll 间隔与 TaskTokenBadge 数字线性动画时长共用 |
 | `src/lib/sse.js` | `connectSSE()` — EventSource `?locale=`；`log` → `formatLogEntry`；`tool_call_end` → `formatToolResult`；任务名 `task.<name>`；流式节流/尾部窗口等同前 |
 | `src/lib/i18n/index.js` | `uiLocale`、`t`/`translate`（`{name}`）、`formatKeyedMessage`/`formatLogEntry`/`formatToolResult`（服务端 key + `{0}`）、`translateServerMessage` legacy 兜底 |
 | `src/lib/i18n/zh.js`, `en.js` | 扁平 key 字典；新增可见文案必须同时在两个文件加 key |
 | `src/pages/Projects.svelte` | 项目选择页：新建项目（名称全宽 + 中文/EN 分段按钮选语言，POST 时携带 `language`）+ 项目列表（每项显示语言 badge，可选择/删除）；选中项目后 `setLocale(project.language)` |
-| `src/pages/Config.svelte` | 配置页：API 配置（含 `url_strict` 严格 URL 模式、解析后 endpoint 预览、上下文预算 tokens）、故事配置（直接 PUT 保存 + 关键设定变更时提示协调）、写作风格与叙述视角、AI 配置变更确认面板（`ConfigChangePanel`）、角色管理、世界观管理、组织管理（卡片 + 成员勾选）、关系管理（卡片 + 源/目标实体选择）；任务运行时所有输入控件禁用 |
+| `src/pages/Config.svelte` | 配置页：API 配置（含 `url_strict` 严格 URL 模式、解析后 endpoint 预览、上下文预算 tokens、连接测试结果持久化展示——结果存 `apiTestResult` store 切页不丢失，成功/失败以文字+着色卡片与按钮描边展示，修改任一影响连接的字段后自动清除）、故事配置（直接 PUT 保存 + 关键设定变更时提示协调）、写作风格与叙述视角、AI 配置变更确认面板（`ConfigChangePanel`）、角色管理、世界观管理、组织管理（卡片 + 成员勾选）、关系管理（卡片 + 源/目标实体选择）；任务运行时所有输入控件禁用 |
 | `src/pages/Outline.svelte` | 大纲页：直接操作按钮（生成/确认/修订意见/删除/生成后续大纲）+ **卷结构面板**（生成卷骨架、按卷生成/重生成章纲（可附本卷补充要求）、追加新卷）+ **导入流水线**（本地切章预览 → 开始导入 → 断点恢复横幅，`GET /api/import/status` 探测）+ pending 章节内联编辑 + 流式预览 + 标题/梗概展示优先 config（`preferUserValue` 一致）+ `ConfigChangePanel` + 未登记大纲人物确认面板（SSE `outline_character_suggestions`） |
 | `src/components/ConfigChangePanel.svelte` | AI 配置变更确认面板：展示 pending 提案（当前 vs 建议）、勾选采纳 / 全部忽略；SSE `config_change_proposal` 触发 |
 | `src/pages/Writing.svelte` | 写作页（v3：正文按需经 `GET /api/chapters/{num}` 拉取，`content_rev` 变化时刷新缓存；字数展示用索引里的 `word_count`；导出走 `GET /api/export/txt`；正文以 block 列表渲染，hover 出现 编辑/AI 修订/插入/删除 工具条，内联编辑与段落级 AI 修订）：章节列表（状态点）+ 直接操作（生成/确认/修改意见/去AI味，自动区分当前章修订与定向修订）+ 正文框选后浮动「引用到修改意见」按钮（插入 `> ` 引用行，触发段落级修订）+ 事实核查冲突处理面板（`pending_writing_conflict`，可选修改大纲/伏笔/重试/保留稿进入审核）+ 自动确认模式开关（toggle，随时可开关）+ 伏笔追踪摘要卡片（活跃/超期/临近回收）+ 优化章节衔接（进度卡片工具栏小按钮，已确认 ≥ 2 章时显示）+ 导出 TXT + 复制 + 上下章导航 + 流式尾部窗口展示（含「仅显示最新内容」提示；任务进行中当前章显示 taskTokenUsage，空闲时以 `countProseUnits` 显示正文字数）+ rAF 自动滚动（自动确认模式下自动跟随正在生成的章节）+ 全书完成后展示 `PostProcessPanel` |

--- a/frontend/src/lib/i18n/en.js
+++ b/frontend/src/lib/i18n/en.js
@@ -319,6 +319,8 @@ export default {
   'config.api.testing': 'Testing...',
   'config.api.saved': 'API config saved',
   'config.api.testOk': 'Connection succeeded. Model {model} responded normally.',
+  'config.api.testResultOk': 'Last test passed: model {model} responded normally.',
+  'config.api.testResultFail': 'Last test failed: {error}',
 
   'config.story.title': 'Story config',
   'config.story.acceptedHint': 'Confirmed chapters exist. After changing key settings, run reconciliation.',

--- a/frontend/src/lib/i18n/zh.js
+++ b/frontend/src/lib/i18n/zh.js
@@ -323,6 +323,8 @@ export default {
   'config.api.testing': '测试中...',
   'config.api.saved': 'API 配置已保存',
   'config.api.testOk': '连接成功！模型 {model} 正常响应',
+  'config.api.testResultOk': '上次测试通过：模型 {model} 正常响应',
+  'config.api.testResultFail': '上次测试失败：{error}',
 
   'config.story.title': '故事配置',
   'config.story.acceptedHint': '已有已确认章节，修改关键设定后建议执行设定协调。',

--- a/frontend/src/lib/stores.js
+++ b/frontend/src/lib/stores.js
@@ -39,6 +39,10 @@ export const logEntries = writable([]);
 // 重试信息：记录最后一次失败的任务
 export const lastFailedTask = writable(null);
 
+// LLM 连接测试结果：{ ok, model?, error?, snapshot }，snapshot 为被测配置的 JSON。
+// 存全局 store 使其在切换页面后仍可见；表单内容与 snapshot 不一致时前端自动隐藏。
+export const apiTestResult = writable(null);
+
 export function addLog(entry) {
   logEntries.update(entries => {
     const next = [...entries, entry];

--- a/frontend/src/pages/Config.svelte
+++ b/frontend/src/pages/Config.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from 'svelte';
   import { api } from '../lib/api.js';
-  import { apiConfig, config, progress, settings, editingCharID, editingWvID, wvFilter, addToast, showConfirm, taskRunning } from '../lib/stores.js';
+  import { apiConfig, config, progress, settings, editingCharID, editingWvID, wvFilter, addToast, showConfirm, taskRunning, apiTestResult } from '../lib/stores.js';
   import { t } from '../lib/i18n/index.js';
   import { resolveChatCompletionsURL } from '../lib/apiUrl.js';
   import ConfigChangePanel from '../components/ConfigChangePanel.svelte';
@@ -119,12 +119,19 @@
     } catch (e) { addToast(e.message, 'error'); }
   }
 
+  // 影响连接测试的字段签名；配置改动后据此自动清除持久化的测试结果
+  const apiTestSig = c => JSON.stringify([c.base_url, !!c.url_strict, c.model, c.api_key, c.http_timeout_seconds, c.max_tokens]);
+  $: if ($apiTestResult && apiTestSig(localApiCfg) !== $apiTestResult.sig) apiTestResult.set(null);
+
   async function testAPIConfig() {
     testingApi = true;
+    const sig = apiTestSig(localApiCfg);
     try {
       const res = await api('POST', '/api/config/api/test', localApiCfg);
+      apiTestResult.set({ ok: true, model: res.model, sig });
       addToast($t('config.api.testOk', { model: res.model }), 'success');
     } catch (e) {
+      apiTestResult.set({ ok: false, error: e.message, sig });
       addToast(e.message, 'error');
     } finally {
       testingApi = false;
@@ -411,8 +418,17 @@
             <input type="password" class="input input-sm w-full" bind:value={localApiCfg.api_key} placeholder="sk-..." disabled={$taskRunning || testingApi} />
           </div>
         </div>
+        {#if $apiTestResult}
+          <div class="text-xs rounded-md border px-2.5 py-1.5 {$apiTestResult.ok ? 'border-success/40 bg-success/10 text-success' : 'border-error/40 bg-error/10 text-error'}">
+            {#if $apiTestResult.ok}
+              ✓ {$t('config.api.testResultOk', { model: $apiTestResult.model })}
+            {:else}
+              ✕ {$t('config.api.testResultFail', { error: $apiTestResult.error })}
+            {/if}
+          </div>
+        {/if}
         <div class="flex justify-end gap-2">
-          <button class="btn btn-outline btn-xs" on:click={testAPIConfig} disabled={$taskRunning || testingApi}>
+          <button class="btn btn-xs {$apiTestResult ? ($apiTestResult.ok ? 'btn-success btn-outline' : 'btn-error btn-outline') : 'btn-outline'}" on:click={testAPIConfig} disabled={$taskRunning || testingApi}>
             {#if testingApi}
               <span class="loading loading-spinner loading-xs"></span>{$t('config.api.testing')}
             {:else}


### PR DESCRIPTION
## Summary
- Toast-only feedback for the LLM connection test disappears when switching pages; persist the result in a global `apiTestResult` store so it survives navigation.
- Show the last test outcome as a colored card (success green / failure red with the error message) plus matching button outline on the config page.
- Auto-clear the persisted result whenever any connection-affecting field (base_url, url_strict, model, api_key, timeout, max_tokens) changes.

## Test plan
- [x] `npm run build` passes
- [ ] Run test, switch to another page and back: result card still visible
- [ ] Edit any API field: result card disappears

Made with [Cursor](https://cursor.com)