### PR TITLE
fix: stabilize relations ForceGraph for large casts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,8 @@ main.go                      入口：progDir 解析、api.json 加载、//go:em
 | `src/pages/Foreshadows.svelte` | 伏笔页：统计概览 + AI 设计伏笔 + 手动 CRUD + AI 建议确认面板（SSE `foreshadow_suggestions`）+ 伏笔-大纲冲突报告卡片（`last_foreshadow_outline_report`）+ 列表/章节时间线/路线图文档三视图 + 复制/下载 `Foreshadows.md` |
 | `src/pages/Memory.svelte` | 叙事记忆页（只读）：从 `progress.memory_entries` 展示统计（条数/覆盖章节/token 上限/内容字数）+ 列表/按章节时间线两视图 + 分类/章节筛选 + 原文片段预览（v3：片段由后端在 `snippet` 字段解析下发）+ 刷新/复制 |
 | `src/components/PostProcessPanel.svelte` | 全书优化面板：开始全书分析（诊断+核查+路线图）/ 重新核查 / 重新生成路线图 / 清空；诊断与核查报告 Markdown 展示；优化工单表格（勾选、编辑意见、执行选项、diff 对比弹窗） |
-| `src/pages/Relations.svelte` | 图谱页：Canvas 力导向图谱（ForceGraph 类），支持拖拽、滚轮缩放（以光标为中心，0.3x–3x）、hover 高亮（强调 hover 节点与其连线，次强调直接相邻节点，其余淡化） |
+| `src/lib/forceGraphLayout.js` | 图谱布局纯函数：`layoutParams(n)`（√N 间距/斥力）、`fitTransform`（包围盒适配视口）、`kineticEnergy`；`forceGraphLayout.check.js` 自检 |
+| `src/pages/Relations.svelte` | 图谱页：Canvas 力导向图谱（ForceGraph），无画布硬夹边、α 冷却后 fit-to-view、按节点数 √N 调间距；拖拽唤醒仿真；滚轮缩放 0.15x–3x（以光标为中心）；hover 高亮（强调 hover 节点与其连线，次强调直接相邻节点，其余淡化） |
 | `src/pages/Assistant.svelte` | 助理页：聊天会话列表 + 消息区 + 工具调用卡片 + 流式回复 |
 | `src/pages/Skills.svelte` | 技能页：技能表格 + toggle 开关 |
 | `src/components/ChatPanel.svelte` | 右侧聊天面板；任务日志走 `formatLogEntry`；工具结果走 `formatToolResult`；其余同前 |
@@ -669,7 +670,7 @@ Skill 文件格式：YAML frontmatter（`---` 分隔，含 `lang: zh|en`，无 `
 - **SSE**：`connectSSE()` 建立 EventSource 连接，14 种事件类型自动更新 stores（`src/lib/sse.js`）；连接/`open` 时用 `/api/status` 恢复 `taskRunning`（避免刷新丢 `task_start`）；content_chunk/chat_chunk 经 150ms 节流缓冲批量刷入；`chat_message` 的 `task_end` 须始终 `clearChatBuf()`（异步工具子任务仍运行时 `taskCount>0`，否则 reload 后的 messages 与延迟 flush 的 `streaming_text` 重复展示同一段 reply）；`token_usage` 更新 taskTokenUsage，任务运行中 poll `/api/status` 兜底（间隔与 `TaskTokenBadge` 数字线性动画时长共用 `frontend/src/lib/tokenPoll.js` 的 `TOKEN_POLL_INTERVAL_MS`）；任务成功完成以 toast 提示（不弹全屏遮罩）
 - **Markdown 渲染**：助理消息通过 `src/lib/markdown.js`（marked + DOMPurify）渲染为 HTML，样式在 `app.css` 的 `.md-body` 块中定义
 - **开发模式**：`task dev:frontend` 启动 Vite dev server（端口 5173），代理 `/api` → `:48090`，支持 HMR 热重载
-- **关系图谱**：`ForceGraph` 类，纯 Canvas 力导向布局，支持拖拽节点、滚轮缩放（以光标为中心）、悬浮 tooltip 与 hover 高亮（hover 节点及连线强调、相邻节点次强调、无关元素淡化）
+- **关系图谱**：`ForceGraph` 类，纯 Canvas 力导向布局；布局参数随 √N 放大、去掉画布硬边界以避免多节点墙弹乱跳，α 冷却/动能阈值后自动 `fitTransform` 适配视口；拖拽会唤醒仿真，滚轮缩放（0.15x–3x，以光标为中心）后不再自动 fit；悬浮 tooltip 与 hover 高亮（hover 节点及连线强调、相邻节点次强调、无关元素淡化）
 - **聊天**：会话列表 + 停止按钮 + 任务状态/日志区 + 消息区 + 工具调用卡片（中文工具名、危险工具高亮、running/done 状态区分）+ 智能自动滚动 + 失败重试 banner
 - **交互原则**：所有核心操作（生成/确认/修订/删除/保存）均为直接按钮 + API 调用，不依赖 AI 聊天间接执行；破坏性操作前端用 `ConfirmModal` 二次确认
 - **i18n 模块**：`src/lib/i18n/index.js` 提供 `uiLocale` store（writable，写入 `localStorage`）、`setLocale(lang)`、`getLocale()`、`t` 派生 store（`$t('key', params)`）、`translate(key, params, lang)` 命令式版本、`translateServerMessage(msg, lang)` 把后端中文消息映射到英文；字典在 `src/lib/i18n/zh.js` 与 `en.js`（扁平 key 表，缺 key 时回退中文），插值占位符为 `{name}`

--- a/frontend/src/lib/forceGraphLayout.check.js
+++ b/frontend/src/lib/forceGraphLayout.check.js
@@ -1,0 +1,31 @@
+/**
+ * Self-check: node frontend/src/lib/forceGraphLayout.check.js
+ */
+import assert from 'node:assert/strict';
+import { layoutParams, fitTransform, kineticEnergy } from './forceGraphLayout.js';
+
+const p8 = layoutParams(8);
+const p32 = layoutParams(32);
+assert.ok(p32.restLength > p8.restLength);
+assert.ok(p32.repulsion > p8.repulsion);
+assert.ok(p32.charOrbit > p8.charOrbit);
+assert.ok(p32.centerPull < p8.centerPull);
+
+const fit = fitTransform(
+  [
+    { x: 0, y: 0, r: 10 },
+    { x: 400, y: 200, r: 10 },
+  ],
+  800,
+  600,
+);
+assert.ok(fit.scale > 0 && fit.scale <= 3);
+assert.ok(Number.isFinite(fit.panX) && Number.isFinite(fit.panY));
+
+const empty = fitTransform([], 800, 600);
+assert.equal(empty.scale, 1);
+
+assert.ok(kineticEnergy([{ vx: 3, vy: 4 }]) === 25);
+assert.equal(kineticEnergy([]), 0);
+
+console.log('forceGraphLayout.check: ok');

--- a/frontend/src/lib/forceGraphLayout.js
+++ b/frontend/src/lib/forceGraphLayout.js
@@ -1,0 +1,64 @@
+/**
+ * Pure layout helpers for Relations ForceGraph.
+ * Spacing / repulsion scale with √N so denser casts do not collapse into the viewport box.
+ */
+
+/** @param {number} n node count */
+export function layoutParams(n) {
+  const count = Math.max(n, 1);
+  // ponytail: √N density vs baseline ~8 nodes; upgrade to Barnes–Hut if casts >> 200
+  const density = Math.sqrt(count / 8);
+  return {
+    restLength: 170 * density,
+    repulsion: 2200 * density * density,
+    charOrbit: 180 * density,
+    worldviewOrbit: 240 * density,
+    orgOrbit: 300 * density,
+    centerPull: 0.0006 / density,
+  };
+}
+
+/**
+ * Camera transform that fits all nodes into the viewport.
+ * @param {{x:number,y:number,r?:number}[]} nodes
+ * @param {number} viewW
+ * @param {number} viewH
+ * @param {{padding?:number,minScale?:number,maxScale?:number}} [opts]
+ */
+export function fitTransform(nodes, viewW, viewH, opts = {}) {
+  const padding = opts.padding ?? 48;
+  const minScale = opts.minScale ?? 0.15;
+  const maxScale = opts.maxScale ?? 3;
+  if (!nodes.length || viewW <= 0 || viewH <= 0) {
+    return { scale: 1, panX: 0, panY: 0 };
+  }
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const n of nodes) {
+    const r = n.r ?? 0;
+    minX = Math.min(minX, n.x - r);
+    minY = Math.min(minY, n.y - r);
+    maxX = Math.max(maxX, n.x + r);
+    maxY = Math.max(maxY, n.y + r);
+  }
+  const bw = Math.max(maxX - minX, 1);
+  const bh = Math.max(maxY - minY, 1);
+  const scale = Math.max(
+    minScale,
+    Math.min(maxScale, Math.min((viewW - 2 * padding) / bw, (viewH - 2 * padding) / bh)),
+  );
+  return {
+    scale,
+    panX: (viewW - bw * scale) / 2 - minX * scale,
+    panY: (viewH - bh * scale) / 2 - minY * scale,
+  };
+}
+
+/** Sum of squared velocities — used as a settle signal. */
+export function kineticEnergy(nodes) {
+  let e = 0;
+  for (const n of nodes) e += (n.vx || 0) ** 2 + (n.vy || 0) ** 2;
+  return e;
+}

--- a/frontend/src/pages/Relations.svelte
+++ b/frontend/src/pages/Relations.svelte
@@ -3,6 +3,7 @@
   import { api } from '../lib/api.js';
   import { settings } from '../lib/stores.js';
   import { t, uiLocale } from '../lib/i18n/index.js';
+  import { layoutParams, fitTransform, kineticEnergy } from '../lib/forceGraphLayout.js';
 
   let canvas;
   let container;
@@ -26,28 +27,55 @@
       this.scale = 1;
       this.panX = 0;
       this.panY = 0;
+      this.alpha = 1;
+      this.needsFit = true;
+      this.params = layoutParams(1);
       this.running = true;
       this.updateData(data);
       this.setupEvents();
       this.tick();
     }
     updateData(data) {
-      this.nodes = [];
-      this.edges = [];
+      const prev = new Map(this.nodes.map(n => [n.id, n]));
       const chars = data.characters || [];
       const wvs = data.worldview || [];
       const orgs = data.organizations || [];
+      const total = chars.length + wvs.length + orgs.length;
+      this.params = layoutParams(total);
       const cx = this.canvas.width / 2;
       const cy = this.canvas.height / 2;
-      chars.forEach((c, i) => {
-        this.nodes.push({ id: c.id, label: stripNameMarks(c.name), type: 'character', x: cx + Math.cos(i * 2) * 180, y: cy + Math.sin(i * 2) * 180, vx: 0, vy: 0, r: 28 });
-      });
-      wvs.forEach((w, i) => {
-        this.nodes.push({ id: w.id, label: stripNameMarks(w.name), type: 'worldview', x: cx + Math.cos(i * 2 + 1) * 240, y: cy + Math.sin(i * 2 + 1) * 240, vx: 0, vy: 0, r: 24 });
-      });
-      orgs.forEach((o, i) => {
-        this.nodes.push({ id: o.id, label: stripNameMarks(o.name), type: 'organization', x: cx + Math.cos(i * 2 + 2) * 300, y: cy + Math.sin(i * 2 + 2) * 300, vx: 0, vy: 0, r: 26 });
-      });
+      const next = [];
+      const place = (list, type, orbit, r) => {
+        const n = list.length;
+        list.forEach((item, i) => {
+          const old = prev.get(item.id);
+          if (old) {
+            next.push({ id: item.id, label: stripNameMarks(item.name), type, x: old.x, y: old.y, vx: old.vx, vy: old.vy, r });
+            return;
+          }
+          const a = n ? (i / n) * Math.PI * 2 : 0;
+          next.push({
+            id: item.id,
+            label: stripNameMarks(item.name),
+            type,
+            x: cx + Math.cos(a) * orbit,
+            y: cy + Math.sin(a) * orbit,
+            vx: 0,
+            vy: 0,
+            r,
+          });
+        });
+      };
+      place(chars, 'character', this.params.charOrbit, 28);
+      place(wvs, 'worldview', this.params.worldviewOrbit, 24);
+      place(orgs, 'organization', this.params.orgOrbit, 26);
+
+      const prevIds = [...prev.keys()].sort().join(',');
+      const nextIds = next.map(n => n.id).sort().join(',');
+      const structureChanged = prevIds !== nextIds;
+
+      this.nodes = next;
+      this.edges = [];
       (data.relations || []).forEach(r => {
         this.edges.push({ source: r.source_id, target: r.target_id, label: r.label });
       });
@@ -56,10 +84,31 @@
           this.edges.push({ source: o.id, target: mid, label: memberEdgeLabel });
         });
       });
+
+      if (structureChanged) {
+        this.alpha = 1;
+        this.needsFit = true;
+      }
     }
-    resize(w, h) { this.canvas.width = w; this.canvas.height = h; }
+    resize(w, h) {
+      this.canvas.width = w;
+      this.canvas.height = h;
+      // Viewport changed after a settled layout — re-fit so the graph still fills the area.
+      if (this.alpha < 0.005 && this.nodes.length) {
+        this.needsFit = true;
+      }
+    }
     destroy() { this.running = false; }
     toWorld(mx, my) { return { x: (mx - this.panX) / this.scale, y: (my - this.panY) / this.scale }; }
+    wake(minAlpha = 0.35) {
+      this.alpha = Math.max(this.alpha, minAlpha);
+    }
+    fitView() {
+      const t = fitTransform(this.nodes, this.canvas.width, this.canvas.height);
+      this.scale = t.scale;
+      this.panX = t.panX;
+      this.panY = t.panY;
+    }
     setupEvents() {
       const c = this.canvas;
       c.addEventListener('mousedown', e => {
@@ -68,17 +117,30 @@
         for (let i = this.nodes.length - 1; i >= 0; i--) {
           const n = this.nodes[i];
           if (Math.hypot(n.x - p.x, n.y - p.y) < n.r + 4) {
-            this.dragging = n; this.offsetX = n.x - p.x; this.offsetY = n.y - p.y; break;
+            this.dragging = n;
+            this.offsetX = n.x - p.x;
+            this.offsetY = n.y - p.y;
+            this.wake(0.4);
+            break;
           }
         }
       });
       c.addEventListener('mousemove', e => {
         const r = c.getBoundingClientRect();
         const p = this.toWorld(e.clientX - r.left, e.clientY - r.top);
-        if (this.dragging) { this.dragging.x = p.x + this.offsetX; this.dragging.y = p.y + this.offsetY; this.dragging.vx = 0; this.dragging.vy = 0; }
+        if (this.dragging) {
+          this.dragging.x = p.x + this.offsetX;
+          this.dragging.y = p.y + this.offsetY;
+          this.dragging.vx = 0;
+          this.dragging.vy = 0;
+          this.wake(0.25);
+        }
         this.hovering = null;
         for (let i = this.nodes.length - 1; i >= 0; i--) {
-          if (Math.hypot(this.nodes[i].x - p.x, this.nodes[i].y - p.y) < this.nodes[i].r + 4) { this.hovering = this.nodes[i]; break; }
+          if (Math.hypot(this.nodes[i].x - p.x, this.nodes[i].y - p.y) < this.nodes[i].r + 4) {
+            this.hovering = this.nodes[i];
+            break;
+          }
         }
         c.style.cursor = this.hovering ? 'pointer' : 'default';
       });
@@ -89,11 +151,11 @@
         const r = c.getBoundingClientRect();
         const mx = e.clientX - r.left, my = e.clientY - r.top;
         const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1;
-        const next = Math.max(0.3, Math.min(3, this.scale * factor));
-        // 以光标位置为中心缩放
+        const next = Math.max(0.15, Math.min(3, this.scale * factor));
         this.panX = mx - (mx - this.panX) * (next / this.scale);
         this.panY = my - (my - this.panY) * (next / this.scale);
         this.scale = next;
+        this.needsFit = false; // user took over the camera
       }, { passive: false });
     }
     tick() {
@@ -103,30 +165,54 @@
       requestAnimationFrame(() => this.tick());
     }
     simulate() {
-      const nodes = this.nodes, k = 0.01, damp = 0.85;
+      if (this.alpha < 0.005) {
+        if (this.needsFit) {
+          this.fitView();
+          this.needsFit = false;
+        }
+        return;
+      }
+      const nodes = this.nodes;
+      const { restLength, repulsion, centerPull } = this.params;
+      const k = 0.01;
+      const damp = 0.85;
+      const a = this.alpha;
       const center = { x: this.canvas.width / 2, y: this.canvas.height / 2 };
+      const byId = new Map(nodes.map(n => [n.id, n]));
+
       for (let i = 0; i < nodes.length; i++) {
         if (nodes[i] === this.dragging) continue;
-        let fx = (center.x - nodes[i].x) * 0.001, fy = (center.y - nodes[i].y) * 0.001;
+        let fx = (center.x - nodes[i].x) * centerPull * a;
+        let fy = (center.y - nodes[i].y) * centerPull * a;
         for (let j = 0; j < nodes.length; j++) {
           if (i === j) continue;
-          const dx = nodes[i].x - nodes[j].x, dy = nodes[i].y - nodes[j].y;
+          const dx = nodes[i].x - nodes[j].x;
+          const dy = nodes[i].y - nodes[j].y;
           const dist = Math.max(Math.hypot(dx, dy), 1);
-          const force = 2200 / (dist * dist);
-          fx += dx / dist * force; fy += dy / dist * force;
+          const force = (repulsion / (dist * dist)) * a;
+          fx += (dx / dist) * force;
+          fy += (dy / dist) * force;
         }
-        nodes[i].vx = (nodes[i].vx + fx) * damp; nodes[i].vy = (nodes[i].vy + fy) * damp;
-        nodes[i].x += nodes[i].vx; nodes[i].y += nodes[i].vy;
-        nodes[i].x = Math.max(nodes[i].r, Math.min(this.canvas.width - nodes[i].r, nodes[i].x));
-        nodes[i].y = Math.max(nodes[i].r, Math.min(this.canvas.height - nodes[i].r, nodes[i].y));
+        nodes[i].vx = (nodes[i].vx + fx) * damp;
+        nodes[i].vy = (nodes[i].vy + fy) * damp;
+        nodes[i].x += nodes[i].vx;
+        nodes[i].y += nodes[i].vy;
       }
       for (const e of this.edges) {
-        const s = nodes.find(n => n.id === e.source), t = nodes.find(n => n.id === e.target);
+        const s = byId.get(e.source);
+        const t = byId.get(e.target);
         if (!s || !t) continue;
         const dx = t.x - s.x, dy = t.y - s.y, dist = Math.max(Math.hypot(dx, dy), 1);
-        const force = (dist - 170) * k, fx = dx / dist * force, fy = dy / dist * force;
+        const force = (dist - restLength) * k * a;
+        const fx = (dx / dist) * force, fy = (dy / dist) * force;
         if (s !== this.dragging) { s.vx += fx; s.vy += fy; }
         if (t !== this.dragging) { t.vx -= fx; t.vy -= fy; }
+      }
+
+      this.alpha *= 0.985;
+      // Settle early when motion is already tiny (avoids long micro-jitter before fit).
+      if (kineticEnergy(nodes) < 0.05 * Math.max(nodes.length, 1) && this.alpha < 0.15) {
+        this.alpha = 0;
       }
     }
     nodePath(ctx, n, pad = 0) {
@@ -158,8 +244,9 @@
           else if (e.target === hov.id) neighborIds.add(e.source);
         }
       }
+      const byId = new Map(this.nodes.map(n => [n.id, n]));
       for (const e of this.edges) {
-        const s = this.nodes.find(n => n.id === e.source), t = this.nodes.find(n => n.id === e.target);
+        const s = byId.get(e.source), t = byId.get(e.target);
         if (!s || !t) continue;
         const connected = hov && (e.source === hov.id || e.target === hov.id);
         ctx.globalAlpha = hov && !connected ? 0.12 : 1;


### PR DESCRIPTION
## Summary
- Remove canvas hard boundary clamping that made dense graphs bounce and jitter
- Scale spring rest length / repulsion / initial orbits with √N; cool simulation (α + kinetic energy) then auto fit-to-view
- Extract pure layout helpers (`forceGraphLayout.js`) with a small node self-check; preserve node positions across non-structural updates

## Test plan
- [ ] Open 图谱 with few characters — layout still settles cleanly; wheel zoom still works
- [ ] Open / create a project with many characters + orgs + relations — nodes should not bounce at edges; after settle the graph fits the viewport
- [ ] Drag a node — simulation wakes briefly then settles again
- [ ] Wheel-zoom after settle — camera stays under user control (no forced re-fit)
- [ ] `node frontend/src/lib/forceGraphLayout.check.js` passes


Made with [Cursor](https://cursor.com)