### PR TITLE
fix: repair foreshadow create/edit modal layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## 项目概述
 
-单二进制 Go Web 应用，Go 后端零外部依赖（仅标准库），通过 OpenAI 兼容 API 自动生成长篇小说。前端使用 Vite + Svelte 4 + DaisyUI 4 构建，产物通过 `embed.FS` 内嵌到二进制中。
+单二进制 Go Web 应用，Go 后端零外部依赖（仅标准库），通过 OpenAI 兼容 API 自动生成长篇小说。前端使用 Vite + Svelte 4 + DaisyUI 5 构建，产物通过 `embed.FS` 内嵌到二进制中。
 
 - **Go 版本**：1.25.1
 - **模块名**：`showmethestory`
@@ -140,7 +140,7 @@ main.go                      入口：progDir 解析、api.json 加载、//go:em
 | `src/components/ConfigChangePanel.svelte` | AI 配置变更确认面板：展示 pending 提案（当前 vs 建议）、勾选采纳 / 全部忽略；SSE `config_change_proposal` 触发 |
 | `src/pages/Writing.svelte` | 写作页（v3：正文按需经 `GET /api/chapters/{num}` 拉取，`content_rev` 变化时刷新缓存；字数展示用索引里的 `word_count`；导出走 `GET /api/export/txt`；正文以 block 列表渲染，hover 出现 编辑/AI 修订/插入/删除 工具条，内联编辑与段落级 AI 修订）：章节列表（状态点）+ 直接操作（生成/确认/修改意见/去AI味，自动区分当前章修订与定向修订）+ 正文框选后浮动「引用到修改意见」按钮（插入 `> ` 引用行，触发段落级修订）+ 事实核查冲突处理面板（`pending_writing_conflict`：改大纲/伏笔/重试/`force_review`；`dismiss`≡保留稿进入审核）+ 孤儿 `writing` 恢复条（无 conflict 记录时仍可重新生成或进入审核）+ 自动确认模式开关（toggle，随时可开关）+ 伏笔追踪摘要卡片（活跃/超期/临近回收）+ 优化章节衔接（进度卡片工具栏小按钮，已确认 ≥ 2 章时显示）+ 导出 TXT + 复制 + 上下章导航 + 流式尾部窗口展示（含「仅显示最新内容」提示；任务进行中当前章显示 taskTokenUsage，空闲时以 `countProseUnits` 显示正文字数）+ rAF 自动滚动（自动确认模式下自动跟随正在生成的章节）+ 全书完成后展示 `PostProcessPanel` |
 | `src/components/TaskTokenBadge.svelte` | 任务 token 展示（`↑ prompt ↓ completion tokens`）；对 `taskTokenUsage` 更新做线性 rAF 插值，动画时长 = `TOKEN_POLL_INTERVAL_MS`；目标值低于当前显示值时该维度从 0 重新向上插值（新一段统计或估算修正）；供 ChatPanel / App 顶栏 / Writing 页复用 |
-| `src/pages/Foreshadows.svelte` | 伏笔页：统计概览 + AI 设计伏笔 + 手动 CRUD + AI 建议确认面板（SSE `foreshadow_suggestions`）+ 伏笔-大纲冲突报告卡片（`last_foreshadow_outline_report`）+ 列表/章节时间线/路线图文档三视图 + 复制/下载 `Foreshadows.md` |
+| `src/pages/Foreshadows.svelte` | 伏笔页：统计概览 + AI 设计伏笔 + 手动 CRUD（`<dialog class="modal">` 创建/编辑表单，DaisyUI 5 字段标签用 `text-xs … block` + `w-full`，不用已移除的 `form-control`/`label-text`）+ AI 建议确认面板（SSE `foreshadow_suggestions`）+ 伏笔-大纲冲突报告卡片（`last_foreshadow_outline_report`）+ 列表/章节时间线/路线图文档三视图 + 复制/下载 `Foreshadows.md` |
 | `src/pages/Memory.svelte` | 叙事记忆页（只读）：从 `progress.memory_entries` 展示统计（条数/覆盖章节/token 上限/内容字数）+ 列表/按章节时间线两视图 + 分类/章节筛选 + 原文片段预览（v3：片段由后端在 `snippet` 字段解析下发）+ 刷新/复制 |
 | `src/components/PostProcessPanel.svelte` | 全书优化面板：开始全书分析（诊断+核查+路线图）/ 重新核查 / 重新生成路线图 / 清空；诊断与核查报告 Markdown 展示；优化工单表格（勾选、编辑意见、执行选项、diff 对比弹窗） |
 | `src/lib/forceGraphLayout.js` | 图谱布局纯函数：`layoutParams(n)`（√N 间距/斥力）、`fitTransform`（包围盒适配视口）、`kineticEnergy`；`forceGraphLayout.check.js` 自检 |

--- a/frontend/src/pages/Foreshadows.svelte
+++ b/frontend/src/pages/Foreshadows.svelte
@@ -442,29 +442,33 @@
   {/if}
 </div>
 
-<!-- 编辑/创建弹窗 -->
+<!-- 编辑/创建弹窗（DaisyUI 5：不用已移除的 form-control / 旧 label-text） -->
 {#if showForm}
-  <div class="modal modal-open">
+  <dialog class="modal modal-open">
     <div class="modal-box max-w-lg">
       <h3 class="font-bold text-lg">{editing ? $t('fs.form.edit') : $t('fs.form.create')}</h3>
-      <div class="form-control gap-3 mt-4">
-        <span class="label py-0"><span class="label-text">{$t('fs.form.name')}</span></span>
-        <input class="input input-bordered input-sm" bind:value={form.name} disabled={$taskRunning} />
-        <span class="label py-0"><span class="label-text">{$t('fs.form.description')}</span></span>
-        <textarea class="textarea textarea-bordered text-sm" rows="3" bind:value={form.description} disabled={$taskRunning}></textarea>
+      <div class="flex flex-col gap-3 mt-4">
+        <div>
+          <span class="text-xs text-base-content/50 mb-0.5 block">{$t('fs.form.name')}</span>
+          <input class="input input-bordered input-sm w-full" bind:value={form.name} disabled={$taskRunning} />
+        </div>
+        <div>
+          <span class="text-xs text-base-content/50 mb-0.5 block">{$t('fs.form.description')}</span>
+          <textarea class="textarea textarea-bordered text-sm w-full" rows="3" bind:value={form.description} disabled={$taskRunning}></textarea>
+        </div>
         <div class="grid grid-cols-2 gap-3">
           <div>
-            <span class="label py-0"><span class="label-text">{$t('fs.form.plant')}</span></span>
+            <span class="text-xs text-base-content/50 mb-0.5 block">{$t('fs.form.plant')}</span>
             <input type="number" min="1" class="input input-bordered input-sm w-full" bind:value={form.plant_chapter} disabled={$taskRunning} />
           </div>
           <div>
-            <span class="label py-0"><span class="label-text">{$t('fs.form.target')}</span></span>
+            <span class="text-xs text-base-content/50 mb-0.5 block">{$t('fs.form.target')}</span>
             <input type="number" min="0" class="input input-bordered input-sm w-full" bind:value={form.target_chapter} disabled={$taskRunning} />
           </div>
         </div>
         {#if editing}
           <div>
-            <span class="label py-0"><span class="label-text">{$t('fs.form.status')}</span></span>
+            <span class="text-xs text-base-content/50 mb-0.5 block">{$t('fs.form.status')}</span>
             <select class="select select-bordered select-sm w-full" bind:value={form.status} disabled={$taskRunning}>
               {#each Object.entries(statusMeta) as [val, meta]}
                 <option value={val}>{meta.label}</option>
@@ -472,7 +476,7 @@
             </select>
           </div>
           <div>
-            <span class="label py-0"><span class="label-text">{$t('fs.form.resolution')}</span></span>
+            <span class="text-xs text-base-content/50 mb-0.5 block">{$t('fs.form.resolution')}</span>
             <input class="input input-bordered input-sm w-full" bind:value={form.resolution} disabled={$taskRunning} />
           </div>
         {/if}
@@ -482,6 +486,6 @@
         <button class="btn btn-primary btn-sm" disabled={$taskRunning} on:click={saveForm}>{$t('common.save')}</button>
       </div>
     </div>
-    <div class="modal-backdrop" on:click={() => showForm = false} on:keydown={() => {}} role="presentation"></div>
-  </div>
+    <form method="dialog" class="modal-backdrop"><button on:click={() => showForm = false}>close</button></form>
+  </dialog>
 {/if}


### PR DESCRIPTION
## Summary
- Fix manual add/edit foreshadow modal broken under DaisyUI 5 (`form-control` removed; `.label` is inline-flex)
- Match Config field labeling (`text-xs … block` + `w-full`) and PostProcess `<dialog class="modal">` + backdrop form pattern
- Correct AGENTS.md overview DaisyUI version (4 → 5)

## Test plan
- [ ] Open 伏笔 → 手动添加：labels stack above inputs with normal gaps; name/description full width
- [ ] Fill form and save — create still works
- [ ] Edit an existing foreshadow — status/resolution fields layout correctly
- [ ] Click backdrop / cancel — modal closes


Made with [Cursor](https://cursor.com)