### PR TITLE
fix: restore the broken star history chart

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -314,10 +314,10 @@ The full architecture, API endpoint list, SSE event reference, design patterns, 
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=Nigh%2Fshow-me-the-story&type=timeline&legend=top-left">
+<a href="https://star-history.dera.page/#Nigh/show-me-the-story&type=timeline&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Nigh/show-me-the-story&type=timeline&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Nigh/show-me-the-story&type=timeline&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Nigh/show-me-the-story&type=timeline&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Nigh/show-me-the-story&type=timeline&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Nigh/show-me-the-story&type=timeline&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Nigh/show-me-the-story&type=timeline&legend=top-left" />
  </picture>
 </a>

--- a/README.md
+++ b/README.md
@@ -300,10 +300,10 @@ task dev:frontend   # 启动 Vite dev server（:5173，热重载，代理 /api �
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=Nigh%2Fshow-me-the-story&type=timeline&legend=top-left">
+<a href="https://star-history.dera.page/#Nigh/show-me-the-story&type=timeline&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Nigh/show-me-the-story&type=timeline&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Nigh/show-me-the-story&type=timeline&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Nigh/show-me-the-story&type=timeline&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Nigh/show-me-the-story&type=timeline&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Nigh/show-me-the-story&type=timeline&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Nigh/show-me-the-story&type=timeline&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The current Star History chart is broken and no longer renders correctly. Update both README language variants so the chart works again while preserving the existing repository and timeline settings.