### PR TITLE
fix: keep auto-write resilient to knowledge sync output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@
 
 ## 结尾控制与事实／设定同步
 
+- 设定同步会丢弃 AI 返回的未支持实体字段，并对 JSON／实体校验失败自动重试一次，避免无风险的格式偏差中断自动连写；聊天失败栏支持直接重试 `knowledge_sync`，自动连写因同步失败停止时任务正确标记为失败。
+
 - `GenerateChapterAction` 在记忆同步后重新取得当前章节引用：同步原子提交会替换章节切片，必须对最新章节设置 review，保证自动确认可继续。`TestGenerateChapterReviewAfterMemorySync` 覆盖记忆提取成功／失败时正文与审核状态落盘、确认后进入下一待写章节。
 
 - 批次请求及元数据增加 `ending_intent`（serial/final/sequel）、`ending_style`（closed/open/custom）、`ending_requirements`，元数据另存 `planned_final`。缺省继续连载，自定义结尾必填要求；向预定完结批次后追加需 `confirm_continue=true`，仅生成保存成功后取消旧标记。正式完结仍是用户手动操作。

--- a/frontend/src/components/ChatPanel.svelte
+++ b/frontend/src/components/ChatPanel.svelte
@@ -54,6 +54,7 @@
     'foreshadow_suggest': { method: 'POST', url: '/api/foreshadows/suggest' },
     'continuation_outline': { method: 'POST', url: '/api/outline/generate-continuation' },
     'settings_reconciliation': { method: 'POST', url: '/api/settings/reconcile' },
+    'knowledge_sync': { method: 'POST', url: '/api/knowledge/sync' },
   };
 
   function isHallucinatedWait(msg, allMsgs, idx) {

--- a/internal/httpapi/handlers.go
+++ b/internal/httpapi/handlers.go
@@ -980,6 +980,7 @@ func (h *Handlers) PostChapterGenerate(w http.ResponseWriter, r *http.Request) {
 		defer h.endTask()
 		h.logger.TaskStart("chapter_generation")
 		ctx := h.activateSkills(h.taskCtx, story.SkillScopeChapterGenerate, true)
+		success := true
 
 		for {
 			chIdx := h.state.CurrentChapterIndex
@@ -1020,6 +1021,7 @@ func (h *Handlers) PostChapterGenerate(w http.ResponseWriter, r *http.Request) {
 			}
 			if err := story.SyncPendingKnowledge(ctx, h.apiCfg, h.cfg, h.state, h.settings, h.progressPath, h.logger); err != nil {
 				h.logger.WarnKey("log.knowledge_failed", err)
+				success = false
 				h.taskCancel()
 				break
 			}
@@ -1036,7 +1038,7 @@ func (h *Handlers) PostChapterGenerate(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		h.logger.TaskEnd("chapter_generation", true)
+		h.logger.TaskEnd("chapter_generation", success)
 		h.broadcastProgress()
 	}()
 

--- a/internal/story/knowledge_test.go
+++ b/internal/story/knowledge_test.go
@@ -211,6 +211,17 @@ func TestSettingsSyncEvidenceConflictsAndHistory(t *testing.T) {
 		t.Fatal("setting provenance not persisted")
 	}
 }
+
+func TestSettingsSyncIgnoresUnknownModelFields(t *testing.T) {
+	ch := factChapter(1, "Alice arrives.")
+	s := &ProjectSettings{}
+	err := applySettingDeltas(s, ch, []settingDelta{{
+		Kind: "characters", Entity: map[string]any{"name": "Alice", "gender": "female"}, BlockID: 1,
+	}})
+	if err != nil || len(s.Characters) != 1 || s.Characters[0].Name != "Alice" {
+		t.Fatalf("safe setting fields were not applied: %v", err)
+	}
+}
 func TestKnowledgeSyncFailureAndNoLegacyBackfill(t *testing.T) {
 	calls := 0
 	cfg := config.DefaultConfigForLang("en")

--- a/internal/story/settings_sync.go
+++ b/internal/story/settings_sync.go
@@ -150,6 +150,20 @@ func validateEntity(s *ProjectSettings, kind string, e map[string]any) error {
 	}
 	return nil
 }
+
+func discardUnknownEntityFields(kind string, e map[string]any) {
+	allowed := map[string]string{
+		"characters":    " id name age appearance personality background motivation abilities notes ",
+		"worldview":     " id category name description tags ",
+		"organizations": " id name type description members ",
+		"relations":     " id source_id source_type target_id target_type label ",
+	}[kind]
+	for k := range e {
+		if !strings.Contains(allowed, " "+k+" ") {
+			delete(e, k)
+		}
+	}
+}
 func newEntityID(s *ProjectSettings, kind string) string {
 	switch kind {
 	case "characters":
@@ -250,6 +264,7 @@ func entityHasDependents(s *ProjectSettings, id string) bool {
 func applySettingDeltas(s *ProjectSettings, ch ChapterState, deltas []settingDelta) error {
 	aliases := map[string]string{}
 	for _, d := range deltas {
+		discardUnknownEntityFields(d.Kind, d.Entity)
 		for _, k := range []string{"source_id", "target_id"} {
 			if id, ok := d.Entity[k].(string); ok && aliases[id] != "" {
 				d.Entity[k] = aliases[id]
@@ -419,22 +434,31 @@ func SyncPendingKnowledge(ctx context.Context, api *config.APIConfig, cfg *confi
 		entities, _ := json.Marshal(settingsEntities(settingsAtChapter(settings, ch.Num)))
 		blocks, _ := json.Marshal(ch.Blocks)
 		prompt := settingUpdatePrompt(cfg.Language) + "\n" + string(entities) + "\n" + string(blocks)
-		raw := llm.CallAPIWithRetryLog(ctx, api, i18n.SystemPromptFor(cfg.Language, "memory_manager"), prompt, logger)
-		if err := ctx.Err(); err != nil {
-			return err
+		var syncErr error
+		for attempt := 0; attempt < 2; attempt++ {
+			raw := llm.CallAPIWithRetryLog(ctx, api, i18n.SystemPromptFor(cfg.Language, "memory_manager"), prompt, logger)
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			var result struct {
+				Changes *[]settingDelta `json:"changes"`
+			}
+			if err := json.Unmarshal([]byte(cleanJSONResponse(raw)), &result); err != nil {
+				syncErr = err
+				continue
+			}
+			if result.Changes == nil {
+				syncErr = fmt.Errorf("%s", i18n.T(cfg.Language, "knowledge_failed"))
+				continue
+			}
+			next = cloneSettings(settings)
+			syncErr = applySettingDeltas(next, ch, *result.Changes)
+			if syncErr == nil {
+				break
+			}
 		}
-		var result struct {
-			Changes *[]settingDelta `json:"changes"`
-		}
-		if err := json.Unmarshal([]byte(cleanJSONResponse(raw)), &result); err != nil {
-			return err
-		}
-		if result.Changes == nil {
-			return fmt.Errorf("%s", i18n.T(cfg.Language, "knowledge_failed"))
-		}
-		next = cloneSettings(settings)
-		if err := applySettingDeltas(next, ch, *result.Changes); err != nil {
-			return err
+		if syncErr != nil {
+			return syncErr
 		}
 		if next.StorySynced == nil {
 			next.StorySynced = map[int]string{}


### PR DESCRIPTION
## Summary
- ignore unsupported AI entity fields and retry invalid setting-sync output once
- allow knowledge-sync retry from the chat failure bar
- report automatic chapter generation as failed when required knowledge sync stops the loop
- add regression coverage and update AGENTS.md

## Verification
- go test ./...
- go build ./...
- npm run build