### PR TITLE
fix: detect interrupted LLM streams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@
 
 ## 批次大纲（当前交互与接口）
 
+- 共用 LLM 流式读取使用 `bufio.Reader`，不再受 Scanner 默认 64 KiB 单行限制；读取失败、损坏 SSE JSON、缺少 `finish_reason` 和 `[DONE]` 的提前 EOF 均返回错误，半截响应不交给大纲 JSON 解析，沿用 API 重试。`data:` 后空格可省略。字符串调用保留 `finish_reason=length` 诊断并停止无效重试；Agent 已收到片段后失败不再拼接同步回退结果。`internal/llm/api_stream_test.go` 覆盖流完整性、长行、请求输出预算和回退。
+
 - 大纲生成标题与提交按钮区分“生成首批大纲”“生成后续大纲”“重新生成末批大纲”。生成章节数输入框右侧实时显示单章或范围（如“此次生成第7章”／“此次生成7-12章”），窄栏换行；按最大已有章号追加，重建按原批起始章且提示“重新生成”。非法数量隐藏范围并禁用提交；范围为 14px，使用 `aria-describedby` 与 `aria-live`，中英文同步。
 
 - 配置页不再提供全书梗概编辑；旧 `config.story.story_synopsis` / `progress.story_synopsis` 保留兼容读取和保存。标题栏显示已保存的小说标题，空白为“无题”/“Untitled”。

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -220,7 +220,7 @@ func callAgentAPI(ctx context.Context, apiCfg *config.APIConfig, messages []llm.
 	if err == nil {
 		return result.FinishReason, nil
 	}
-	if ctx.Err() != nil {
+	if ctx.Err() != nil || result.Content != "" {
 		return "", err
 	}
 	syncResult, err2 := llm.CallAPIMessagesSync(ctx, &agentCfg, messages)

--- a/internal/agent/agent_truncated_test.go
+++ b/internal/agent/agent_truncated_test.go
@@ -1,11 +1,29 @@
 package agent
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"showmethestory/internal/config"
 	"showmethestory/internal/llm"
 	"strings"
 	"testing"
 )
+
+func TestAgentPartialStreamDoesNotAppendFallback(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n")
+	}))
+	defer srv.Close()
+	var output strings.Builder
+	_, err := callAgentAPI(context.Background(), &config.APIConfig{BaseURL: srv.URL}, nil, func(s string) { output.WriteString(s) })
+	if err == nil || calls != 1 || output.String() != "partial" {
+		t.Fatalf("err=%v calls=%d output=%q", err, calls, output.String())
+	}
+}
 
 func TestParseToolCallTruncatedJSONNoRepair(t *testing.T) {
 	// 流式截断：缺 </tool_call> 且 JSON 不完整 — 不修复，parseToolCall 应返回 nil

--- a/internal/llm/api.go
+++ b/internal/llm/api.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -49,6 +50,20 @@ type ChatResponse struct {
 type CompletionResult struct {
 	Content      string
 	FinishReason string // e.g. "stop", "length"
+}
+
+// A server-side output limit will not recover by retrying the same request.
+type outputLimitError struct{ maxTokens int }
+
+func (e *outputLimitError) Error() string {
+	return fmt.Sprintf("API output truncated (finish_reason=length, requested max_tokens=%d); check provider output/reasoning limits or reduce the requested batch size", e.maxTokens)
+}
+
+func completionText(result CompletionResult, err error, maxTokens int) (string, error) {
+	if err == nil && result.FinishReason == "length" {
+		err = &outputLimitError{maxTokens: maxTokens}
+	}
+	return result.Content, err
 }
 
 func hasAPIVersionSegment(u string) bool {
@@ -158,6 +173,10 @@ func IsFatalAPIError(err error) bool {
 	if err == nil {
 		return false
 	}
+	var limit *outputLimitError
+	if errors.As(err, &limit) {
+		return true
+	}
 	msg := err.Error()
 	// 注意：不要把所有 "dial tcp" 都当作致命错误——
 	// "dial tcp ... i/o timeout" 等临时网络故障应当重试。
@@ -189,7 +208,7 @@ func CallAPIMessages(ctx context.Context, apiCfg *config.APIConfig, messages []M
 	messages = applyPromptAddon(ctx, messages)
 	result, err := CallAPIStreamMessages(ctx, apiCfg, messages, nil)
 	if err == nil && result.Content != "" {
-		return result.Content, nil
+		return completionText(result, nil, apiCfg.MaxTokens)
 	}
 	if ctx.Err() != nil {
 		if result.Content != "" {
@@ -203,9 +222,9 @@ func CallAPIMessages(ctx context.Context, apiCfg *config.APIConfig, messages []M
 	if err != nil && IsFatalAPIError(err) {
 		return "", err
 	}
-	// ponytail: fallback for providers with broken stream; loses finish_reason + stream estimate.
+	// Fall back only before any stream content has been received.
 	syncResult, syncErr := CallAPIMessagesSync(ctx, apiCfg, messages)
-	return syncResult.Content, syncErr
+	return completionText(syncResult, syncErr, apiCfg.MaxTokens)
 }
 
 // CallAPIMessagesSync 同步 HTTP 调用（仅作流式失败时的回退）。
@@ -345,7 +364,7 @@ func CallAPIStream(ctx context.Context, apiCfg *config.APIConfig, system, user s
 		{Role: "system", Content: system},
 		{Role: "user", Content: user},
 	}, onChunk)
-	return result.Content, err
+	return completionText(result, err, apiCfg.MaxTokens)
 }
 
 // CallAPIStreamMessages 以完整的多轮消息数组调用 API（流式）。
@@ -391,26 +410,32 @@ func CallAPIStreamMessages(ctx context.Context, apiCfg *config.APIConfig, messag
 	}
 
 	var fullContent strings.Builder
-	scanner := bufio.NewScanner(resp.Body)
+	reader := bufio.NewReader(resp.Body)
 	var streamUsage *tokenUsage
 	var finishReason string
+	var readErr error
+	done := false
 
-	for scanner.Scan() {
+	for readErr == nil {
 		if ctx.Err() != nil {
 			return CompletionResult{Content: fullContent.String(), FinishReason: finishReason}, ctx.Err()
 		}
-		line := scanner.Text()
-		if !strings.HasPrefix(line, "data: ") {
+		var line string
+		line, readErr = reader.ReadString('\n')
+		line = strings.TrimRight(line, "\r\n")
+		if !strings.HasPrefix(line, "data:") {
 			continue
 		}
-		data := strings.TrimPrefix(line, "data: ")
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
 		if data == "[DONE]" {
+			done = true
 			break
 		}
 
 		var delta streamDelta
 		if err := json.Unmarshal([]byte(data), &delta); err != nil {
-			continue
+			readErr = fmt.Errorf("invalid SSE JSON: %w", err)
+			break
 		}
 		if delta.Usage != nil {
 			streamUsage = delta.Usage
@@ -433,9 +458,6 @@ func CallAPIStreamMessages(ctx context.Context, apiCfg *config.APIConfig, messag
 	}
 
 	result := fullContent.String()
-	if result == "" {
-		return CompletionResult{}, fmt.Errorf("流式响应为空")
-	}
 	if tracker != nil {
 		if streamUsage != nil {
 			tracker.finishCall(streamUsage.PromptTokens, streamUsage.CompletionTokens, true, messages, result)
@@ -443,5 +465,18 @@ func CallAPIStreamMessages(ctx context.Context, apiCfg *config.APIConfig, messag
 			tracker.finishCall(0, 0, false, messages, result)
 		}
 	}
-	return CompletionResult{Content: result, FinishReason: finishReason}, nil
+	completion := CompletionResult{Content: result, FinishReason: finishReason}
+	if ctx.Err() != nil {
+		return completion, ctx.Err()
+	}
+	if readErr != nil && readErr != io.EOF {
+		return completion, fmt.Errorf("stream interrupted after %d bytes: %w", len(result), readErr)
+	}
+	if !done && finishReason == "" {
+		return completion, fmt.Errorf("stream ended without finish_reason or [DONE] after %d bytes: %w", len(result), io.ErrUnexpectedEOF)
+	}
+	if result == "" {
+		return completion, fmt.Errorf("流式响应为空")
+	}
+	return completion, nil
 }

--- a/internal/llm/api_stream_test.go
+++ b/internal/llm/api_stream_test.go
@@ -1,0 +1,109 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"showmethestory/internal/config"
+)
+
+func TestStreamIntegrity(t *testing.T) {
+	chunk := func(content, reason string) string {
+		return fmt.Sprintf("data:{\"choices\":[{\"delta\":{\"content\":%q},\"finish_reason\":%q}]}\r\n\r\n", content, reason)
+	}
+	long := strings.Repeat("章", 30000)
+	for _, tt := range []struct {
+		name, wire, want, reason, errText string
+		shortBody                         bool
+	}{
+		{name: "done", wire: chunk("ok", "") + "data: [DONE]", want: "ok"},
+		{name: "finish", wire: chunk("ok", "stop"), want: "ok", reason: "stop"},
+		{name: "large event", wire: chunk(long, "stop"), want: long, reason: "stop"},
+		{name: "early EOF", wire: chunk("partial", ""), want: "partial", errText: "without finish_reason"},
+		{name: "broken JSON", wire: chunk("partial", "") + "data: {broken}\n\ndata: [DONE]\n", want: "partial", errText: "invalid SSE JSON"},
+		{name: "read error", wire: chunk("partial", ""), want: "partial", shortBody: true, errText: "unexpected EOF"},
+		{name: "length", wire: chunk("partial", "length"), want: "partial", reason: "length"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req ChatRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Error(err)
+				}
+				if req.MaxTokens != 32768 || !req.Stream {
+					t.Errorf("request budget/stream changed: %+v", req)
+				}
+				if tt.shortBody {
+					w.Header().Set("Content-Length", fmt.Sprint(len(tt.wire)+100))
+				}
+				fmt.Fprint(w, tt.wire)
+			}))
+			defer srv.Close()
+			cfg := &config.APIConfig{BaseURL: srv.URL, MaxTokens: 32768}
+			var chunks strings.Builder
+			got, err := CallAPIStreamMessages(context.Background(), cfg, nil, func(s string) { chunks.WriteString(s) })
+			if got.Content != tt.want || chunks.String() != tt.want || got.FinishReason != tt.reason {
+				t.Fatalf("content or finish reason mismatch: content bytes=%d reason=%q", len(got.Content), got.FinishReason)
+			}
+			if tt.errText == "" && err != nil || tt.errText != "" && (err == nil || !strings.Contains(err.Error(), tt.errText)) {
+				t.Fatalf("error=%v, want %q", err, tt.errText)
+			}
+		})
+	}
+}
+
+func TestBufferedCompletionErrors(t *testing.T) {
+	for _, mode := range []string{"partial", "length", "fallback", "fallback length", "timeout"} {
+		t.Run(mode, func(t *testing.T) {
+			calls := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				var req ChatRequest
+				json.NewDecoder(r.Body).Decode(&req)
+				if req.Stream {
+					if strings.HasPrefix(mode, "fallback") {
+						http.Error(w, "stream unsupported", http.StatusBadRequest)
+						return
+					}
+					fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n")
+					if mode == "length" {
+						fmt.Fprint(w, "data: {\"choices\":[{\"finish_reason\":\"length\"}]}\n\n")
+					}
+					if mode == "timeout" {
+						w.(http.Flusher).Flush()
+						<-r.Context().Done()
+					}
+					return
+				}
+				reason := "stop"
+				if mode == "fallback length" {
+					reason = "length"
+				}
+				fmt.Fprintf(w, "{\"choices\":[{\"message\":{\"content\":\"complete\"},\"finish_reason\":%q}]}", reason)
+			}))
+			defer srv.Close()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			_, err := CallAPIMessages(ctx, &config.APIConfig{BaseURL: srv.URL, MaxTokens: 32768}, nil)
+			if (mode == "fallback") != (err == nil) {
+				t.Fatalf("error=%v", err)
+			}
+			if strings.Contains(mode, "length") && (!IsFatalAPIError(err) || !strings.Contains(err.Error(), "finish_reason=length")) {
+				t.Fatalf("missing non-retryable limit diagnostic: %v", err)
+			}
+			wantCalls := 1
+			if strings.HasPrefix(mode, "fallback") {
+				wantCalls = 2
+			}
+			if calls != wantCalls {
+				t.Fatalf("calls=%d, want %d", calls, wantCalls)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes partial LLM stream responses being passed to JSON parsers as successful output. Detects interrupted or malformed SSE, handles lines over Scanner's default limit, and surfaces provider output limits.\n\nValidation: go test ./...; go build ./...; go vet ./...