### PR TITLE
refactor: remove unreleased v4 compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ main.go
 - 每个模型请求以 `ContextBudgetTokens - MaxTokens - max(4096, 5% 上下文窗口)` 作为保守估算的输入上限；模型端点能报告更小的真实窗口时自动向下收紧配置，最终预检超限属于不可重试错误。
 - 提示词占位符是 `config.RenderPrompt` 的 `{{.Key}}` 字符串替换，不是 `text/template`。
 - 新增 prompt 字段时同步更新 `PromptsConfig`、中英默认模板和 `ApplyDefaults`；新增注入块或 system prompt 必须同时提供中英文。
-- Skill 包为 `skill.json + SKILL.md`，仅接受安全校验后的 `.md/.txt/.json`；所有 Skill 默认禁用，并按项目语言、`applies_to` 和动作类别过滤。
+- Skill 包必须包含 schema v1 的 `skill.json` 及其声明的 Markdown 入口（通常为 `SKILL.md`），仅接受安全校验后的 `.md/.txt/.json`；所有 Skill 默认禁用，并按项目语言、`applies_to` 和动作类别过滤。
 - 内置 Skill 位于 `internal/story/embeds/skills/`，修改后需要重新编译。
 
 ## 前端约定

--- a/internal/story/blocks.go
+++ b/internal/story/blocks.go
@@ -201,7 +201,6 @@ func ReviseBlockAction(ctx context.Context, apiCfg *config.APIConfig, cfg *confi
 		"SegmentOriginal":  original,
 		"UserFeedback":     feedbackForAI,
 	})
-	userPrompt = appendIfMissingPlaceholder(cfg.Prompts.ChapterSegmentRevision, userPrompt, "{{.WritingPOV}}", formatWritingPOVBlock(cfg.Story.WritingPOV, lang))
 	userPrompt += factProtection(state, ch.Num, lang)
 
 	systemPrompt := state.CorePrompt

--- a/internal/story/history_compression.go
+++ b/internal/story/history_compression.go
@@ -180,8 +180,7 @@ func checkpointFor(ctx context.Context, api *config.APIConfig, cfg *config.Confi
 	if err := ctx.Err(); err != nil {
 		return NarrativeCheckpoint{}, err
 	}
-	// Version the hash to rebuild legacy checkpoints whose fallback provenance is unknown.
-	hash := checkpointHash([]string{"v2", checkpointHash(parts), checkpointHash(revisions)})
+	hash := checkpointHash(append(append([]string{}, parts...), revisions...))
 	key := fmt.Sprintf("%d:%d:%d", level, start, end)
 	if cp, ok := old[key]; ok && !cp.Degraded && cp.SourceHash == hash && strings.TrimSpace(cp.Summary) != "" {
 		return cp, nil

--- a/internal/story/outline_helpers.go
+++ b/internal/story/outline_helpers.go
@@ -121,7 +121,6 @@ func mergeOutlinePromptData(base map[string]string, cfg *config.Config, settings
 func finalizeOutlinePrompt(template, rendered string, cfg *config.Config, settings *ProjectSettings) string {
 	lang := cfg.Language
 	minLen, maxLen := calcOutlineLengthRange(cfg.Story.TargetWordsPerChapter)
-	rendered = appendIfMissingPlaceholder(template, rendered, "{{.CharacterList}}", formatCharacterListForOutline(settings, lang))
 	if !strings.Contains(template, "{{.OutlineMinWords}}") {
 		block := formatOutlineLengthRequirementBlock(minLen, maxLen, lang) + "\n" + formatOutlineStructureRequirementBlock(lang)
 		rendered += "\n\n" + block

--- a/internal/story/skill_registry.go
+++ b/internal/story/skill_registry.go
@@ -158,41 +158,13 @@ func normalizeSkillFiles(files map[string][]byte) (SkillManifest, map[string][]b
 		}
 		cleaned[clean] = b
 	}
-	var manifest SkillManifest
-	if raw, ok := cleaned["skill.json"]; ok {
-		if err := json.Unmarshal(raw, &manifest); err != nil {
-			return manifest, nil, fmt.Errorf("invalid skill.json: %w", err)
-		}
-	} else {
-		entry := "SKILL.md"
-		raw, ok := cleaned[entry]
-		if !ok {
-			var markdownFiles []string
-			for name := range cleaned {
-				if strings.EqualFold(filepath.Ext(name), ".md") {
-					markdownFiles = append(markdownFiles, name)
-				}
-			}
-			sort.Strings(markdownFiles)
-			if len(markdownFiles) == 1 {
-				entry = markdownFiles[0]
-				raw = cleaned[entry]
-				ok = true
-			}
-		}
-		if !ok {
-			return manifest, nil, fmt.Errorf("SKILL.md is required")
-		}
-		s, err := parseSkillFile(string(raw), "user")
-		if err != nil {
-			return manifest, nil, err
-		}
-		manifest = SkillManifest{SchemaVersion: 1, ID: s.ID, Name: s.Name, Description: s.Description, Category: s.Category, Languages: s.Languages, AppliesTo: s.AppliesTo, EntryPoint: entry}
-		mb, _ := json.MarshalIndent(manifest, "", "  ")
-		cleaned["skill.json"] = mb
+	raw, ok := cleaned["skill.json"]
+	if !ok {
+		return SkillManifest{}, nil, fmt.Errorf("skill.json is required")
 	}
-	if manifest.SchemaVersion == 0 {
-		manifest.SchemaVersion = 1
+	var manifest SkillManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return manifest, nil, fmt.Errorf("invalid skill.json: %w", err)
 	}
 	if manifest.SchemaVersion != 1 {
 		return manifest, nil, fmt.Errorf("unsupported skill schema version")

--- a/internal/story/skill_registry_test.go
+++ b/internal/story/skill_registry_test.go
@@ -13,9 +13,14 @@ func testSkillMarkdown(body string) []byte {
 	return []byte("---\nid: test-skill\nname: Test Skill\ndescription: test\ncategory: writing\nlang: en\napplies_to: [chapter.generate]\n---\n\n" + body)
 }
 
+func testSkillFiles(body string) map[string][]byte {
+	manifest := []byte(`{"schema_version":1,"id":"test-skill","name":"Test Skill","description":"test","category":"writing","languages":["en"],"applies_to":["chapter.generate"],"entrypoint":"SKILL.md"}`)
+	return map[string][]byte{"skill.json": manifest, "SKILL.md": testSkillMarkdown(body)}
+}
+
 func TestInstallSkillAndInvalidateValidationOnContentChange(t *testing.T) {
 	dir := t.TempDir()
-	first, err := InstallSkillFiles(dir, map[string][]byte{"SKILL.md": testSkillMarkdown("first")}, false)
+	first, err := InstallSkillFiles(dir, testSkillFiles("first"), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,12 +34,23 @@ func TestInstallSkillAndInvalidateValidationOnContentChange(t *testing.T) {
 	if len(loaded) != 1 || loaded[0].Validation == nil || loaded[0].Validation.Status != "passed" {
 		t.Fatalf("validation not loaded: %+v", loaded)
 	}
-	second, err := InstallSkillFiles(dir, map[string][]byte{"SKILL.md": testSkillMarkdown("changed")}, true)
+	second, err := InstallSkillFiles(dir, testSkillFiles("changed"), true)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if second.ContentHash == first.ContentHash || second.Validation != nil {
 		t.Fatalf("changed content must invalidate validation: %+v", second)
+	}
+}
+
+func TestSkillPackageRequiresVersionedManifest(t *testing.T) {
+	if _, err := InstallSkillFiles(t.TempDir(), map[string][]byte{"SKILL.md": testSkillMarkdown("body")}, false); err == nil {
+		t.Fatal("expected missing skill.json rejection")
+	}
+	files := testSkillFiles("body")
+	files["skill.json"] = []byte(`{"id":"test-skill","name":"Test Skill","entrypoint":"SKILL.md","applies_to":["chapter.generate"]}`)
+	if _, err := InstallSkillFiles(t.TempDir(), files, false); err == nil {
+		t.Fatal("expected missing schema_version rejection")
 	}
 }
 

--- a/internal/story/writing.go
+++ b/internal/story/writing.go
@@ -564,10 +564,6 @@ func generateChapterContentStream(ctx context.Context, apiCfg *config.APIConfig,
 		"OutlineConstraints": outlineConstraints,
 	})
 	userPrompt = finalizeChapterWritingPrompt(cfg.Prompts.ChapterWriting, userPrompt, minLen, maxLen, targetWords, lang)
-	userPrompt = appendIfMissingPlaceholder(cfg.Prompts.ChapterWriting, userPrompt, "{{.OutlineConstraints}}", outlineConstraints)
-	userPrompt = appendIfMissingPlaceholder(cfg.Prompts.ChapterWriting, userPrompt, "{{.Foreshadows}}", foreshadowContext)
-	userPrompt = appendIfMissingPlaceholder(cfg.Prompts.ChapterWriting, userPrompt, "{{.Memory}}", memoryContext)
-	userPrompt = appendIfMissingPlaceholder(cfg.Prompts.ChapterWriting, userPrompt, "{{.WritingPOV}}", formatWritingPOVBlock(cfg.Story.WritingPOV, lang))
 	if block := formatExtraWritingConstraintsBlock(extraWritingConstraints, lang); block != "" {
 		userPrompt += "\n\n" + block
 	}
@@ -665,29 +661,6 @@ func generateChapterFactCheck(ctx context.Context, apiCfg *config.APIConfig, cfg
 		"OutlineConstraints": outlineConstraints,
 		"Memory":             memoryContext,
 	})
-	// Old-template fallback: if placeholder is missing, append the material and supplementary checks at the end.
-	if i18n.NormalizeLanguage(lang) == i18n.LangEN {
-		userPrompt = appendIfMissingPlaceholder(cfg.Prompts.FactCheck, userPrompt, "{{.ChapterOutline}}",
-			"[Chapter outline]\n"+ch.Outline)
-		if outlineConstraints != "" {
-			userPrompt = appendIfMissingPlaceholder(cfg.Prompts.FactCheck, userPrompt, "{{.OutlineConstraints}}",
-				outlineConstraints+"Supplementary audit scope (also count as reportable objective contradictions): (a) premature introduction of characters/events scheduled for later chapters per the outline; (b) one-time events from prior chapters (first meetings, identity reveals, etc.) being re-enacted as new in this chapter.")
-		}
-		if memoryContext != "" {
-			userPrompt = appendIfMissingPlaceholder(cfg.Prompts.FactCheck, userPrompt, "{{.Memory}}", memoryContext)
-		}
-	} else {
-		userPrompt = appendIfMissingPlaceholder(cfg.Prompts.FactCheck, userPrompt, "{{.ChapterOutline}}",
-			"【本章大纲】\n"+ch.Outline)
-		if outlineConstraints != "" {
-			userPrompt = appendIfMissingPlaceholder(cfg.Prompts.FactCheck, userPrompt, "{{.OutlineConstraints}}",
-				outlineConstraints+"补充核查范围（同样属于必须报告的客观矛盾）：(a) 提前引入按章节脉络安排在后续章节才登场或发生的人物/事件；(b) 前文已发生的一次性事件（初次见面、身份揭示等）在本章作为新事件重复发生。")
-		}
-		if memoryContext != "" {
-			userPrompt = appendIfMissingPlaceholder(cfg.Prompts.FactCheck, userPrompt, "{{.Memory}}", memoryContext)
-		}
-	}
-
 	systemPrompt := i18n.SystemPromptFor(lang, "fact_checker_json")
 	return llm.CallAPI(ctx, apiCfg, systemPrompt, userPrompt)
 }
@@ -836,7 +809,6 @@ func reviseChapterSegment(ctx context.Context, apiCfg *config.APIConfig, cfg *co
 		"SegmentOriginal":  segmentOriginal,
 		"UserFeedback":     feedbackForAI,
 	})
-	userPrompt = appendIfMissingPlaceholder(cfg.Prompts.ChapterSegmentRevision, userPrompt, "{{.WritingPOV}}", formatWritingPOVBlock(cfg.Story.WritingPOV, lang))
 	userPrompt = appendIfMissingPlaceholder(cfg.Prompts.ChapterSegmentRevision, userPrompt, "{{.UserFeedback}}", feedbackForAI)
 	userPrompt += factProtection(state, ch.Num, lang)
 
@@ -900,7 +872,6 @@ func reviseChapterContentStream(ctx context.Context, apiCfg *config.APIConfig, c
 		"OriginalContent":  ch.Content,
 		"UserFeedback":     userFeedback,
 	})
-	userPrompt = appendIfMissingPlaceholder(cfg.Prompts.ChapterRevision, userPrompt, "{{.WritingPOV}}", formatWritingPOVBlock(cfg.Story.WritingPOV, lang))
 	userPrompt = appendIfMissingPlaceholder(cfg.Prompts.ChapterRevision, userPrompt, "{{.UserFeedback}}", userFeedback)
 	userPrompt += factProtection(state, ch.Num, lang)
 
@@ -988,7 +959,6 @@ func reviseSubsequentOutlines(ctx context.Context, apiCfg *config.APIConfig, cfg
 // futureOutlineWindow 注入后续章节大纲的窗口大小（章数）
 const futureOutlineWindow = 10
 
-// appendIfMissingPlaceholder keeps required context in customized prompts
 // that omit a supported placeholder.
 func appendIfMissingPlaceholder(template, rendered, placeholder, block string) string {
 	if strings.TrimSpace(block) == "" || strings.Contains(template, placeholder) {

--- a/internal/story/writing_conflict.go
+++ b/internal/story/writing_conflict.go
@@ -52,8 +52,6 @@ func analyzeWritingConflict(ctx context.Context, apiCfg *config.APIConfig, cfg *
 		"FailedIssues":       strings.Join(failedIssues, "\n"),
 		"ContentExcerpt":     excerpt,
 	})
-	userPrompt = appendIfMissingPlaceholder(cfg.Prompts.WritingConflictAnalysis, userPrompt, "{{.OutlineConstraints}}", outlineConstraints)
-	userPrompt = appendIfMissingPlaceholder(cfg.Prompts.WritingConflictAnalysis, userPrompt, "{{.Foreshadows}}", foreshadowBlock)
 
 	systemPrompt := i18n.SystemPromptFor(lang, "writing_conflict_analyst_json")
 	rawResp := llm.CallAPIWithRetryLog(ctx, apiCfg, systemPrompt, userPrompt, logger)


### PR DESCRIPTION
## Summary
- require the final versioned Skill package format
- remove prompt fallbacks for unreleased templates while retaining required author feedback injection
- remove the development-only narrative checkpoint hash migration

## Validation
- go build ./...
- go test ./...
- go vet ./...